### PR TITLE
Generate detection crops during inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+.terraform.lock.hcl
+crash.log
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+.pytest_cache/
+
+# Node / frontend build
+node_modules/
+dist/
+.vite/
+
+# IDE / OS
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db
+
+# Local env
+.env
+.env.local

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -212,13 +212,15 @@ def main():
                     except Exception as exc:
                         log.append(f"crop: could not open {local_fp}: {exc}")
                         break
-                crop_local = os.path.join(tmpdir, f"{doc_id}_{idx}.jpg")
+                stem = Path(filename).stem
+                crop_filename = f"{stem}_detection_{idx + 1}.jpg"
+                crop_local = os.path.join(tmpdir, crop_filename)
                 try:
                     _save_crop(source_image, det["bbox"], crop_local)
                 except Exception as exc:
                     log.append(f"crop: failed for {filename} det {idx}: {exc}")
                     continue
-                crop_gcs_path = f"crops/{uid}/{folder}/{doc_id}_{idx}.jpg"
+                crop_gcs_path = f"crops/{uid}/{folder}/{crop_filename}"
                 bucket.blob(crop_gcs_path).upload_from_filename(
                     crop_local, content_type="image/jpeg"
                 )

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -17,10 +17,35 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from google.cloud import firestore, storage
+from PIL import Image
+
+CROP_CONF_THRESHOLD = 0.2
+CROP_MAX_DIM        = 512
+CROP_JPEG_QUALITY   = 85
 
 # ── ANSI / tqdm helpers (same as local backend) ───────────────────────────────
 _ANSI_ESCAPE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07|\r')
 _TQDM_RE = re.compile(r'^(.+?)\s*:\s*(\d+)%\|[^|]*\|\s*(\d+)/(\d+)')
+
+
+def _save_crop(image: Image.Image, bbox: list, dest_path: str) -> None:
+    """Crop `bbox` (normalised [x, y, w, h]) from `image` and save JPEG to `dest_path`."""
+    w, h = image.size
+    bx, by, bw, bh = bbox
+    x0 = max(0, int(bx * w))
+    y0 = max(0, int(by * h))
+    x1 = min(w, int((bx + bw) * w))
+    y1 = min(h, int((by + bh) * h))
+    if x1 <= x0 or y1 <= y0:
+        return
+    crop = image.crop((x0, y0, x1, y1))
+    cw, ch = crop.size
+    scale = min(1.0, CROP_MAX_DIM / max(cw, ch))
+    if scale < 1.0:
+        crop = crop.resize((int(cw * scale), int(ch * scale)), Image.LANCZOS)
+    if crop.mode != "RGB":
+        crop = crop.convert("RGB")
+    crop.save(dest_path, "JPEG", quality=CROP_JPEG_QUALITY, optimize=True)
 
 
 def _parse_label(label_str: str) -> dict:
@@ -176,6 +201,31 @@ def main():
                 ):
                     top5.append({**_parse_label(cls), "score": round(score, 4)})
 
+            detections = pred.get("detections", [])
+            source_image = None
+            for idx, det in enumerate(detections):
+                if det.get("conf", 0) < CROP_CONF_THRESHOLD or not det.get("bbox"):
+                    continue
+                if source_image is None:
+                    try:
+                        source_image = Image.open(local_fp)
+                    except Exception as exc:
+                        log.append(f"crop: could not open {local_fp}: {exc}")
+                        break
+                crop_local = os.path.join(tmpdir, f"{doc_id}_{idx}.jpg")
+                try:
+                    _save_crop(source_image, det["bbox"], crop_local)
+                except Exception as exc:
+                    log.append(f"crop: failed for {filename} det {idx}: {exc}")
+                    continue
+                crop_gcs_path = f"crops/{uid}/{folder}/{doc_id}_{idx}.jpg"
+                bucket.blob(crop_gcs_path).upload_from_filename(
+                    crop_local, content_type="image/jpeg"
+                )
+                det["crop_gcs_path"] = crop_gcs_path
+            if source_image is not None:
+                source_image.close()
+
             doc = {
                 "gcs_path":          gcs_path,
                 "filename":          filename,
@@ -185,7 +235,7 @@ def main():
                 "prediction_score":  pred.get("prediction_score"),
                 "prediction_source": pred.get("prediction_source"),
                 "top5":              top5,
-                "detections":        pred.get("detections", []),
+                "detections":        detections,
                 "model_version":     pred.get("model_version"),
                 "failures":          pred.get("failures", []),
                 "country":           pred.get("country"),

--- a/infra/inference/requirements.txt
+++ b/infra/inference/requirements.txt
@@ -1,3 +1,4 @@
 speciesnet
 google-cloud-storage>=2.14
 google-cloud-firestore>=2.15
+Pillow>=10.0

--- a/webapp/backend/main_cloud.py
+++ b/webapp/backend/main_cloud.py
@@ -130,7 +130,7 @@ async def get_image(
         uid = fb_auth.verify_id_token(raw_token)["uid"]
     except Exception as exc:
         raise HTTPException(status_code=401, detail=f"Invalid token: {exc}")
-    if not path.startswith(f"images/{uid}/"):
+    if not (path.startswith(f"images/{uid}/") or path.startswith(f"crops/{uid}/")):
         raise HTTPException(status_code=403, detail="Access denied")
     url = _bucket.blob(path).generate_signed_url(
         expiration=timedelta(minutes=15),

--- a/webapp/frontend/src/components/DetectionCrop.vue
+++ b/webapp/frontend/src/components/DetectionCrop.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="crop">
-    <canvas ref="canvasRef" class="crop__canvas" />
+    <img
+      v-if="det.crop_gcs_path"
+      :src="imageUrl(det.crop_gcs_path)"
+      class="crop__img"
+      :alt="det.label"
+    />
+    <canvas v-else ref="canvasRef" class="crop__canvas" />
     <span class="crop__badge" :style="{ background: color }">
       {{ det.label }} {{ (det.conf * 100).toFixed(0) }}%
     </span>
@@ -9,6 +15,7 @@
 
 <script setup>
 import { ref, onMounted, watch } from 'vue'
+import { imageUrl } from '../firebase.js'
 
 const props = defineProps({
   imageSrc: String,
@@ -20,6 +27,7 @@ const canvasRef = ref(null)
 const TARGET_H = 110
 
 function draw() {
+  if (props.det.crop_gcs_path) return   // using <img>, nothing to paint
   const canvas = canvasRef.value
   if (!canvas) return
 
@@ -54,7 +62,8 @@ watch(() => [props.imageSrc, props.det], draw)
   border: 1px solid var(--border);
 }
 
-.crop__canvas {
+.crop__canvas,
+.crop__img {
   display: block;
   height: 110px;
   width: auto;


### PR DESCRIPTION
## Summary
- Generate per-detection crop JPEGs during the inference job (conf >= 0.2, max 512px long edge) and upload them to `crops/{uid}/{folder}/{doc_id}_{idx}.jpg`
- Store the GCS path on each detection so the UI can load just the crop instead of the full image
- Widen `/api/image` to serve `crops/{uid}/...` as well as `images/{uid}/...`
- DetectionCrop.vue uses `<img>` when a crop path is present, falling back to the existing canvas-from-full-image path when absent
- First-time `.gitignore` in this repo — excludes terraform state/tfvars so secrets don't leak

## Why
Carousel of detection crops was re-downloading each full-resolution image per crop. Pre-crop at inference time so pages that only need thumbnails load fast.

## Test plan
- [x] Rebuild & push inference image (`deploy-inference.ps1`)
- [x] Rebuild & push api image (`deploy-api.ps1`)
- [x] Run inference on a new folder — verify `crops/.../` objects appear in GCS
- [x] Open a photo modal — detection carousel should render from `/api/image?path=crops/...`
- [x] Load an older prediction (no `crop_gcs_path`) — fallback canvas path still works