### PR TITLE
Add species view with taxonomy tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ npm install
 npm run dev                         # localhost:5173
 ```
 
-The frontend's `AUTH_ENABLED` flag in `firebase.js` auto-disables when no
-real Firebase config is present, so local dev skips sign-in entirely.
+The frontend's `AUTH_ENABLED` flag in `firebase.js` is tied to Vite's
+build mode: `npm run dev` skips sign-in, production builds require it.
 
 ## Cloud deployment
 

--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -30,6 +30,18 @@
         <span>{{ stats.images }} images</span>
         <span>{{ stats.species }} species</span>
       </div>
+      <div class="app-header__views">
+        <button
+          class="app-header__view-btn"
+          :class="{ 'app-header__view-btn--active': view === 'gallery' }"
+          @click="view = 'gallery'"
+        >Gallery</button>
+        <button
+          class="app-header__view-btn"
+          :class="{ 'app-header__view-btn--active': view === 'species' }"
+          @click="view = 'species'"
+        >Species</button>
+      </div>
       <div class="app-header__right">
         <button class="app-header__process-btn" @click="showProcess = true">+ Add Photos</button>
         <button v-if="currentUser" class="app-header__user-btn" :title="`Sign out ${currentUser.email}`" @click="handleSignOut">
@@ -41,6 +53,7 @@
 
     <div class="app-body">
       <FilterBar
+        v-if="view === 'gallery'"
         :species="allSpecies"
         :filters="filters"
         :total="predictions.length"
@@ -53,12 +66,19 @@
       <main class="app-main">
         <div v-if="loading" class="state-msg">Loading predictions…</div>
         <div v-else-if="error" class="state-msg state-msg--error">{{ error }}</div>
-        <div v-else-if="groupedEvents.length === 0" class="state-msg">No images match the current filters.</div>
-        <ImageGallery
+        <template v-else-if="view === 'gallery'">
+          <div v-if="groupedEvents.length === 0" class="state-msg">No images match the current filters.</div>
+          <ImageGallery
+            v-else
+            :events="groupedEvents"
+            @select="openModal"
+            @day-select="selectedDay = $event"
+          />
+        </template>
+        <SpeciesView
           v-else
-          :events="groupedEvents"
+          :predictions="predictions"
           @select="openModal"
-          @day-select="selectedDay = $event"
         />
       </main>
     </div>
@@ -95,6 +115,7 @@ import ImageGallery from './components/ImageGallery.vue'
 import ImageModal from './components/ImageModal.vue'
 import DaySummary from './components/DaySummary.vue'
 import ProcessModal from './components/ProcessModal.vue'
+import SpeciesView from './components/SpeciesView.vue'
 import { auth, AUTH_ENABLED, apiFetch, signInWithGoogle, signOutUser, onIdTokenChanged } from './firebase.js'
 
 const predictions  = ref([])
@@ -103,6 +124,7 @@ const error        = ref(null)
 const selectedImage = ref(null)
 const selectedDay  = ref(null)
 const showProcess  = ref(false)
+const view         = ref('gallery')  // 'gallery' | 'species'
 const dataDateFrom = ref('')
 const dataDateTo   = ref('')
 
@@ -369,6 +391,35 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.app-header__views {
+  display: flex;
+  gap: 4px;
+  background: var(--bg-alt, #111);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2px;
+}
+
+.app-header__view-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 4px 12px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.app-header__view-btn:hover { color: var(--text); }
+
+.app-header__view-btn--active {
+  background: var(--accent, #2d7d46);
+  color: white;
 }
 
 .app-header__process-btn {

--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -79,6 +79,7 @@
           v-else
           :predictions="predictions"
           @select="openModal"
+          @filter="applyHistogramFilter"
         />
       </main>
     </div>
@@ -124,7 +125,7 @@ const error        = ref(null)
 const selectedImage = ref(null)
 const selectedDay  = ref(null)
 const showProcess  = ref(false)
-const view         = ref('gallery')  // 'gallery' | 'species'
+const view         = ref('species')  // 'gallery' | 'species'
 const dataDateFrom = ref('')
 const dataDateTo   = ref('')
 
@@ -139,6 +140,7 @@ const filters = reactive({
   categories: ['animal', 'human', 'vehicle', 'blank', 'unknown'],
   dateFrom: '',
   dateTo: '',
+  hour: null,
 })
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
@@ -209,6 +211,11 @@ const filteredPredictions = computed(() => {
     if (!filters.categories.includes(cat)) return false
     if (filters.species && p.prediction?.common_name !== filters.species) return false
     if (filters.minConfidence > 0 && (p.prediction_score ?? 0) < filters.minConfidence / 100) return false
+    if (filters.hour !== null) {
+      const ts = p.captured_at || p.filename || ''
+      const h = ts.length >= 10 ? parseInt(ts.slice(8, 10), 10) : -1
+      if (h !== filters.hour) return false
+    }
     if (from || to) {
       const ts   = p.filename.substring(0, 8)
       const date = `${ts.slice(0,4)}-${ts.slice(4,6)}-${ts.slice(6,8)}`
@@ -255,6 +262,12 @@ function filenameToDate(filename) {
 }
 
 function openModal(image) { selectedImage.value = image }
+
+function applyHistogramFilter({ species, hour }) {
+  filters.species = species
+  filters.hour    = hour
+  view.value      = 'gallery'
+}
 
 async function onProcessDone() {
   showProcess.value = false

--- a/webapp/frontend/src/components/FilterBar.vue
+++ b/webapp/frontend/src/components/FilterBar.vue
@@ -56,6 +56,14 @@
       </div>
     </div>
 
+    <div v-if="filters.hour !== null" class="filterbar__section">
+      <label class="filterbar__label">Hour filter</label>
+      <div class="filterbar__chip">
+        {{ filters.hour }}:00–{{ filters.hour }}:59
+        <button class="filterbar__chip-clear" @click="emit('update', { hour: null })">✕</button>
+      </div>
+    </div>
+
     <div class="filterbar__footer">
       <span class="filterbar__count">{{ filtered }} / {{ total }}</span>
       <button class="filterbar__clear" @click="clearFilters">Clear</button>
@@ -101,6 +109,7 @@ function clearFilters() {
     categories: CATEGORIES.map(c => c.key),
     dateFrom: props.dateFromMin ?? '',
     dateTo: props.dateToMax ?? '',
+    hour: null,
   })
 }
 </script>
@@ -182,6 +191,28 @@ function clearFilters() {
   height: 14px;
   cursor: pointer;
 }
+
+.filterbar__chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface2);
+  border: 1px solid var(--accent, #2d7d46);
+  border-radius: var(--radius);
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--text);
+}
+.filterbar__chip-clear {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0 0 0 6px;
+  font-size: 12px;
+  line-height: 1;
+}
+.filterbar__chip-clear:hover { color: var(--text); }
 
 .filterbar__footer {
   margin-top: auto;

--- a/webapp/frontend/src/components/SpeciesView.vue
+++ b/webapp/frontend/src/components/SpeciesView.vue
@@ -20,18 +20,90 @@
             <span v-if="card.scientific" class="species-card__scientific">{{ card.scientific }}</span>
             <span class="species-card__count">{{ card.count }} detection{{ card.count === 1 ? '' : 's' }}</span>
           </header>
+          <div class="species-card__body">
+            <div class="species-card__histogram">
+              <div class="histogram__block">
+                <div class="histogram__title">Time of Day</div>
+                <div class="histogram__chart">
+                  <div class="histogram__y-axis">
+                    <span>{{ Math.max(...card.hours) }}</span>
+                    <span>0</span>
+                  </div>
+                  <div class="histogram__bars-wrap">
+                    <svg class="histogram__svg" viewBox="0 0 240 48" preserveAspectRatio="none">
+                      <line x1="0" y1="0" x2="0" y2="48" class="histogram__axis" />
+                      <rect
+                        v-for="(n, h) in card.hours"
+                        :key="h"
+                        :x="h * 10 + 1"
+                        :width="8"
+                        :height="card.hours[h] === 0 ? 1 : Math.max(2, (n / Math.max(...card.hours)) * 44)"
+                        :y="48 - (card.hours[h] === 0 ? 1 : Math.max(2, (n / Math.max(...card.hours)) * 44))"
+                        :class="['histogram__bar', { 'histogram__bar--zero': n === 0, 'histogram__bar--hover': barHover?.id === `${card.key}-h${h}` }]"
+                        @click="emit('filter', { species: card.rawName, hour: h })"
+                        @mouseenter="barHover = { id: `${card.key}-h${h}`, label: `${h}:00–${h}:59`, count: n, x: $event.clientX, y: $event.clientY }"
+                        @mousemove="barHover = { ...barHover, x: $event.clientX, y: $event.clientY }"
+                        @mouseleave="barHover = null"
+                      />
+                    </svg>
+                    <div class="histogram__labels">
+                      <span>12a</span><span>6a</span><span>12p</span><span>6p</span><span>12a</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="histogram__block">
+                <div class="histogram__title">Month of Year</div>
+                <div class="histogram__chart">
+                  <div class="histogram__y-axis">
+                    <span>{{ Math.max(...card.months) }}</span>
+                    <span>0</span>
+                  </div>
+                  <div class="histogram__bars-wrap">
+                    <svg class="histogram__svg" viewBox="0 0 120 48" preserveAspectRatio="none">
+                      <line x1="0" y1="0" x2="0" y2="48" class="histogram__axis" />
+                      <rect
+                        v-for="(n, m) in card.months"
+                        :key="m"
+                        :x="m * 10 + 1"
+                        :width="8"
+                        :height="card.months[m] === 0 ? 1 : Math.max(2, (n / Math.max(...card.months)) * 44)"
+                        :y="48 - (card.months[m] === 0 ? 1 : Math.max(2, (n / Math.max(...card.months)) * 44))"
+                        :class="['histogram__bar', { 'histogram__bar--zero': n === 0, 'histogram__bar--hover': barHover?.id === `${card.key}-m${m}` }]"
+                        @mouseenter="barHover = { id: `${card.key}-m${m}`, label: MONTH_NAMES[m], count: n, x: $event.clientX, y: $event.clientY }"
+                        @mousemove="barHover = { ...barHover, x: $event.clientX, y: $event.clientY }"
+                        @mouseleave="barHover = null"
+                      />
+                    </svg>
+                    <div class="histogram__labels">
+                      <span>Jan</span><span>Apr</span><span>Jul</span><span>Oct</span><span>Dec</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
           <div class="species-card__crops">
             <button
               v-for="top in card.top"
-              :key="top.pred.gcs_path"
+              :key="imagePathOf(top.pred)"
               class="species-card__crop"
               @click="$emit('select', top.pred)"
+              @mouseenter="showPreview(top, $event)"
+              @mousemove="movePreview($event)"
+              @mouseleave="hidePreview"
             >
               <img
                 v-if="top.cropPath"
                 :src="imageUrl(top.cropPath)"
                 :alt="card.commonName"
                 loading="lazy"
+              />
+              <div
+                v-else-if="top.bbox"
+                class="species-card__crop-bbox"
+                :style="bboxStyle(top)"
               />
               <div v-else class="species-card__crop-placeholder">no crop</div>
               <div class="species-card__crop-meta">
@@ -40,19 +112,53 @@
               </div>
             </button>
           </div>
+          </div>
         </article>
       </div>
     </section>
+
+    <Teleport to="body">
+      <img
+        v-if="preview.src"
+        class="species-view__preview"
+        :src="preview.src"
+        :style="{ left: preview.x + 'px', top: preview.y + 'px' }"
+      />
+      <div
+        v-if="barHover"
+        class="species-view__hist-tooltip"
+        :style="{ left: barHover.x + 12 + 'px', top: barHover.y + 12 + 'px' }"
+      >{{ barHover.label }} — {{ barHover.count }} detection{{ barHover.count === 1 ? '' : 's' }}</div>
+    </Teleport>
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, reactive, computed } from 'vue'
+
+const preview  = reactive({ src: null, x: 0, y: 0 })
+const barHover = ref(null)
+
+const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+
+function showPreview(top, e) {
+  preview.src = top.cropPath ? imageUrl(top.cropPath) : null
+  if (preview.src) movePreview(e)
+}
+
+function movePreview(e) {
+  preview.x = e.clientX + 16
+  preview.y = e.clientY + 16
+}
+
+function hidePreview() {
+  preview.src = null
+}
 import TreeNode from './TreeNode.vue'
 import { imageUrl } from '../firebase.js'
 
 const props = defineProps({ predictions: Array })
-defineEmits(['select'])
+const emit = defineEmits(['select', 'filter'])
 
 const selectedPath = ref(null)
 
@@ -155,17 +261,37 @@ const speciesCards = computed(() => {
       const tb = timestampOf(b)
       return tb.localeCompare(ta)
     })
-    const top = sorted.slice(0, 5).map(pred => ({
-      pred,
-      cropPath: bestCropPath(pred),
-      when: formatTimestamp(timestampOf(pred)),
-    }))
+    const top = sorted.slice(0, 5).map(pred => {
+      const det = bestDetection(pred)
+      return {
+        pred,
+        cropPath: det?.crop_gcs_path || null,
+        bbox: det?.bbox || null,
+        when: formatTimestamp(timestampOf(pred)),
+      }
+    })
+    const hours  = new Array(24).fill(0)
+    const months = new Array(12).fill(0)
+    for (const pred of preds) {
+      const ts = timestampOf(pred)
+      if (ts.length >= 10) {
+        const h = parseInt(ts.slice(8, 10), 10)
+        if (h >= 0 && h < 24) hours[h]++
+      }
+      if (ts.length >= 6) {
+        const m = parseInt(ts.slice(4, 6), 10) - 1
+        if (m >= 0 && m < 12) months[m]++
+      }
+    }
     cards.push({
       key: commonName,
+      rawName: commonName,
       commonName: capitalize(commonName),
       scientific: preds[0].prediction?.scientific || '',
       count: preds.length,
       top,
+      hours,
+      months,
     })
   }
 
@@ -178,14 +304,32 @@ function timestampOf(pred) {
   return pred.filename ? pred.filename.substring(0, 14) : ''
 }
 
-function bestCropPath(pred) {
+function imagePathOf(pred) {
+  return pred.gcs_path || pred.filepath || ''
+}
+
+function bestDetection(pred) {
   const dets = pred.detections || []
   let best = null
   for (const d of dets) {
-    if (!d.crop_gcs_path) continue
+    if (!d.bbox) continue
     if (!best || (d.conf ?? 0) > (best.conf ?? 0)) best = d
   }
-  return best?.crop_gcs_path || null
+  return best
+}
+
+function bboxStyle(top) {
+  const [bx, by, bw, bh] = top.bbox
+  if (!bw || !bh) return {}
+  const sizeX = (100 / bw).toFixed(2)
+  const sizeY = (100 / bh).toFixed(2)
+  const posX  = (bx / (1 - bw) * 100).toFixed(2)
+  const posY  = (by / (1 - bh) * 100).toFixed(2)
+  return {
+    backgroundImage: `url("${imageUrl(imagePathOf(top.pred))}")`,
+    backgroundSize: `${sizeX}% ${sizeY}%`,
+    backgroundPosition: `${isFinite(posX) ? posX : 0}% ${isFinite(posY) ? posY : 0}%`,
+  }
 }
 
 function formatTimestamp(ts) {
@@ -228,7 +372,8 @@ function formatTimestamp(ts) {
   border: 1px solid var(--border, #e0e0e0);
   border-radius: 8px;
   padding: 12px;
-  background: white;
+  background: var(--surface);
+  color: var(--text);
 }
 .species-card__header {
   display: flex;
@@ -245,36 +390,150 @@ function formatTimestamp(ts) {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+  flex: 1;
+  min-width: 0;
 }
 .species-card__crop {
+  position: relative;
   flex: 0 0 auto;
-  width: 140px;
+  width: 210px;
   padding: 0;
   background: none;
   border: 1px solid var(--border, #e0e0e0);
   border-radius: 6px;
-  overflow: hidden;
   cursor: pointer;
   display: flex;
   flex-direction: column;
 }
+
+.species-card__crop > img:first-of-type { border-radius: 6px 6px 0 0; }
 .species-card__crop:hover { border-color: var(--accent, #2d7d46); }
-.species-card__crop img { display: block; width: 100%; height: 100px; object-fit: cover; }
+.species-card__crop > img:first-of-type { display: block; width: 100%; height: 150px; object-fit: contain; background: var(--surface2); }
+.species-card__crop-bbox {
+  width: 100%;
+  height: 150px;
+  background-repeat: no-repeat;
+  background-color: var(--surface2);
+}
 .species-card__crop-placeholder {
-  height: 100px;
+  height: 150px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #aaa;
+  color: var(--text-muted);
   font-size: 11px;
-  background: #f5f5f5;
+  background: var(--surface2);
 }
+.species-card__body {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.species-card__histogram {
+  flex: 0 0 420px;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+}
+.histogram__block {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 0;
+}
+.histogram__title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-align: center;
+}
+.histogram__chart {
+  display: flex;
+  gap: 4px;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+}
+.histogram__y-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  font-size: 11px;
+  color: var(--text-muted);
+  padding-bottom: 16px;
+}
+.histogram__bars-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.histogram__svg {
+  display: block;
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: visible;
+}
+.histogram__axis {
+  stroke: var(--border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.histogram__bar {
+  fill: var(--accent, #2d7d46);
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.1s;
+}
+.histogram__bar--zero { fill: var(--border); opacity: 0.4; }
+.histogram__bar--hover { opacity: 1; fill: #4ade80; }
+.histogram__labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--text-muted);
+  padding: 0 1px;
+  margin-top: 2px;
+}
+
+.species-view__hist-tooltip {
+  position: fixed;
+  z-index: 9999;
+  pointer-events: none;
+  background: var(--surface, #1c1c1c);
+  border: 1px solid var(--border, #444);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--text);
+  white-space: nowrap;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+
+.species-view__preview {
+  position: fixed;
+  z-index: 9999;
+  pointer-events: none;
+  max-width: 80vw;
+  max-height: 80vh;
+  width: auto;
+  height: auto;
+  border: 1px solid var(--border, #444);
+  border-radius: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.7);
+}
+
 .species-card__crop-meta {
   display: flex;
   justify-content: space-between;
   padding: 4px 6px;
   font-size: 11px;
-  color: #666;
-  background: #fafafa;
+  color: var(--text-muted);
+  background: var(--surface2);
 }
 </style>

--- a/webapp/frontend/src/components/SpeciesView.vue
+++ b/webapp/frontend/src/components/SpeciesView.vue
@@ -1,0 +1,280 @@
+<template>
+  <div class="species-view">
+    <aside class="species-view__tree">
+      <div class="species-view__tree-header">Species hierarchy</div>
+      <TreeNode
+        v-if="tree"
+        :node="tree"
+        :selected-path="selectedPath"
+        @select="selectedPath = $event.path"
+      />
+    </aside>
+
+    <section class="species-view__list">
+      <div v-if="!selectedPath" class="state-msg">Select a node in the tree to see species.</div>
+      <div v-else-if="speciesCards.length === 0" class="state-msg">No detections under this node.</div>
+      <div v-else class="species-cards">
+        <article v-for="card in speciesCards" :key="card.key" class="species-card">
+          <header class="species-card__header">
+            <span class="species-card__name">{{ card.commonName }}</span>
+            <span v-if="card.scientific" class="species-card__scientific">{{ card.scientific }}</span>
+            <span class="species-card__count">{{ card.count }} detection{{ card.count === 1 ? '' : 's' }}</span>
+          </header>
+          <div class="species-card__crops">
+            <button
+              v-for="top in card.top"
+              :key="top.pred.gcs_path"
+              class="species-card__crop"
+              @click="$emit('select', top.pred)"
+            >
+              <img
+                v-if="top.cropPath"
+                :src="imageUrl(top.cropPath)"
+                :alt="card.commonName"
+                loading="lazy"
+              />
+              <div v-else class="species-card__crop-placeholder">no crop</div>
+              <div class="species-card__crop-meta">
+                <span>{{ Math.round((top.pred.prediction_score ?? 0) * 100) }}%</span>
+                <span v-if="top.when">{{ top.when }}</span>
+              </div>
+            </button>
+          </div>
+        </article>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import TreeNode from './TreeNode.vue'
+import { imageUrl } from '../firebase.js'
+
+const props = defineProps({ predictions: Array })
+defineEmits(['select'])
+
+const selectedPath = ref(null)
+
+// ── Build the taxonomy tree from prediction.raw (semicolon-separated) ─────────
+// SpeciesNet label format: "{uuid};{kingdom};{phylum};{class};{order};{family};{genus};{species};{common_name}"
+function taxonomyChain(pred) {
+  const raw = pred.prediction?.raw
+  if (!raw) return null
+  const parts = raw.split(';').map(p => p.trim())
+  // Drop the uuid at index 0 and the common_name at the end (we'll attach it separately).
+  const levels = parts.slice(1, -1).filter(Boolean)
+  const commonName = parts[parts.length - 1] || pred.prediction?.common_name || 'unknown'
+  return { levels, commonName, scientific: pred.prediction?.scientific || '' }
+}
+
+const tree = computed(() => {
+  const root = { label: 'All species', path: '', children: [], count: 0, preds: [] }
+  const indexByPath = new Map()
+  indexByPath.set('', root)
+
+  for (const pred of props.predictions) {
+    if (!pred.prediction) continue
+    const chain = taxonomyChain(pred)
+    if (!chain) continue
+    const segments = [...chain.levels, chain.commonName]
+
+    let cur = root
+    cur.count++
+    cur.preds.push(pred)
+
+    let path = ''
+    for (let i = 0; i < segments.length; i++) {
+      path = path + '/' + segments[i]
+      let child = indexByPath.get(path)
+      if (!child) {
+        child = {
+          label: capitalize(segments[i]),
+          path,
+          children: [],
+          count: 0,
+          preds: [],
+        }
+        cur.children.push(child)
+        indexByPath.set(path, child)
+      }
+      child.count++
+      child.preds.push(pred)
+      cur = child
+    }
+  }
+
+  sortRecursive(root)
+  return root
+})
+
+function sortRecursive(node) {
+  node.children.sort((a, b) => a.label.localeCompare(b.label))
+  for (const child of node.children) sortRecursive(child)
+}
+
+function capitalize(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s
+}
+
+// ── Right-hand list: species cards for every leaf under the selected node ────
+const selectedNode = computed(() => {
+  if (selectedPath.value == null) return null
+  return findNode(tree.value, selectedPath.value)
+})
+
+function findNode(node, path) {
+  if (node.path === path) return node
+  for (const c of node.children) {
+    const hit = findNode(c, path)
+    if (hit) return hit
+  }
+  return null
+}
+
+const speciesCards = computed(() => {
+  const node = selectedNode.value
+  if (!node) return []
+
+  // Gather by species (common name). If the selected node is itself a species,
+  // this yields exactly one card.
+  const groups = new Map()
+  for (const pred of node.preds) {
+    const name = pred.prediction?.common_name || 'unknown'
+    if (!groups.has(name)) groups.set(name, [])
+    groups.get(name).push(pred)
+  }
+
+  const cards = []
+  for (const [commonName, preds] of groups.entries()) {
+    const sorted = [...preds].sort((a, b) => {
+      const sa = a.prediction_score ?? 0
+      const sb = b.prediction_score ?? 0
+      if (sb !== sa) return sb - sa
+      const ta = timestampOf(a)
+      const tb = timestampOf(b)
+      return tb.localeCompare(ta)
+    })
+    const top = sorted.slice(0, 5).map(pred => ({
+      pred,
+      cropPath: bestCropPath(pred),
+      when: formatTimestamp(timestampOf(pred)),
+    }))
+    cards.push({
+      key: commonName,
+      commonName: capitalize(commonName),
+      scientific: preds[0].prediction?.scientific || '',
+      count: preds.length,
+      top,
+    })
+  }
+
+  cards.sort((a, b) => b.count - a.count)
+  return cards
+})
+
+function timestampOf(pred) {
+  if (pred.captured_at) return pred.captured_at
+  return pred.filename ? pred.filename.substring(0, 14) : ''
+}
+
+function bestCropPath(pred) {
+  const dets = pred.detections || []
+  let best = null
+  for (const d of dets) {
+    if (!d.crop_gcs_path) continue
+    if (!best || (d.conf ?? 0) > (best.conf ?? 0)) best = d
+  }
+  return best?.crop_gcs_path || null
+}
+
+function formatTimestamp(ts) {
+  if (!ts || ts.length < 8) return ''
+  const y = ts.slice(0, 4), mo = ts.slice(4, 6), d = ts.slice(6, 8)
+  return `${y}-${mo}-${d}`
+}
+</script>
+
+<style scoped>
+.species-view {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  height: 100%;
+  min-height: 0;
+}
+
+.species-view__tree {
+  overflow-y: auto;
+  border-right: 1px solid var(--border, #e0e0e0);
+  padding: 8px 4px 8px 0;
+}
+.species-view__tree-header {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #888;
+  letter-spacing: 0.05em;
+  padding: 4px 6px 8px;
+}
+
+.species-view__list { overflow-y: auto; padding: 8px 12px; }
+
+.state-msg { padding: 24px; color: #888; font-size: 14px; }
+
+.species-cards { display: flex; flex-direction: column; gap: 16px; }
+
+.species-card {
+  border: 1px solid var(--border, #e0e0e0);
+  border-radius: 8px;
+  padding: 12px;
+  background: white;
+}
+.species-card__header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+.species-card__name { font-size: 16px; font-weight: 600; }
+.species-card__scientific { font-size: 12px; color: #888; font-style: italic; }
+.species-card__count { margin-left: auto; font-size: 12px; color: #666; }
+
+.species-card__crops {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.species-card__crop {
+  flex: 0 0 auto;
+  width: 140px;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--border, #e0e0e0);
+  border-radius: 6px;
+  overflow: hidden;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+}
+.species-card__crop:hover { border-color: var(--accent, #2d7d46); }
+.species-card__crop img { display: block; width: 100%; height: 100px; object-fit: cover; }
+.species-card__crop-placeholder {
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #aaa;
+  font-size: 11px;
+  background: #f5f5f5;
+}
+.species-card__crop-meta {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 6px;
+  font-size: 11px;
+  color: #666;
+  background: #fafafa;
+}
+</style>

--- a/webapp/frontend/src/components/SpeciesView.vue
+++ b/webapp/frontend/src/components/SpeciesView.vue
@@ -160,6 +160,8 @@ import { imageUrl } from '../firebase.js'
 const props = defineProps({ predictions: Array })
 const emit = defineEmits(['select', 'filter'])
 
+const EXCLUDED_LABELS = new Set(['blank', 'no cv result'])
+
 const selectedPath = ref(null)
 
 // ── Build the taxonomy tree from prediction.raw (semicolon-separated) ─────────
@@ -183,6 +185,7 @@ const tree = computed(() => {
     if (!pred.prediction) continue
     const chain = taxonomyChain(pred)
     if (!chain) continue
+    if (EXCLUDED_LABELS.has(chain.commonName.toLowerCase())) continue
     const segments = [...chain.levels, chain.commonName]
 
     let cur = root
@@ -215,7 +218,7 @@ const tree = computed(() => {
 })
 
 function sortRecursive(node) {
-  node.children.sort((a, b) => a.label.localeCompare(b.label))
+  node.children.sort((a, b) => b.count - a.count)
   for (const child of node.children) sortRecursive(child)
 }
 
@@ -247,6 +250,7 @@ const speciesCards = computed(() => {
   const groups = new Map()
   for (const pred of node.preds) {
     const name = pred.prediction?.common_name || 'unknown'
+    if (EXCLUDED_LABELS.has(name.toLowerCase())) continue
     if (!groups.has(name)) groups.set(name, [])
     groups.get(name).push(pred)
   }

--- a/webapp/frontend/src/components/TreeNode.vue
+++ b/webapp/frontend/src/components/TreeNode.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="tree-node">
+    <button
+      class="tree-node__row"
+      :class="{ 'tree-node__row--selected': selectedPath === node.path }"
+      :style="{ paddingLeft: `${depth * 14 + 6}px` }"
+      @click="$emit('select', node)"
+    >
+      <span
+        v-if="node.children.length"
+        class="tree-node__caret"
+        :class="{ 'tree-node__caret--open': expanded }"
+        @click.stop="expanded = !expanded"
+      >▸</span>
+      <span v-else class="tree-node__caret tree-node__caret--leaf">·</span>
+      <span class="tree-node__label">{{ node.label }}</span>
+      <span class="tree-node__count">{{ node.count }}</span>
+    </button>
+    <div v-if="expanded && node.children.length" class="tree-node__children">
+      <TreeNode
+        v-for="child in node.children"
+        :key="child.path"
+        :node="child"
+        :depth="depth + 1"
+        :selected-path="selectedPath"
+        @select="$emit('select', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  node: Object,
+  depth: { type: Number, default: 0 },
+  selectedPath: String,
+})
+defineEmits(['select'])
+
+// Top-level nodes start expanded; deeper ones collapsed.
+const expanded = ref(props.depth < 1)
+</script>
+
+<style scoped>
+.tree-node__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 4px 6px 4px 6px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text, #222);
+  border-radius: 4px;
+}
+.tree-node__row:hover { background: rgba(0, 0, 0, 0.05); }
+.tree-node__row--selected {
+  background: var(--accent, #2d7d46);
+  color: white;
+}
+.tree-node__row--selected .tree-node__count { color: rgba(255, 255, 255, 0.8); }
+
+.tree-node__caret {
+  width: 12px;
+  font-size: 10px;
+  color: #666;
+  transition: transform 0.15s;
+  user-select: none;
+  flex-shrink: 0;
+}
+.tree-node__caret--open { transform: rotate(90deg); }
+.tree-node__caret--leaf { color: #ccc; }
+
+.tree-node__label { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tree-node__count {
+  font-size: 11px;
+  color: #888;
+  margin-left: 4px;
+  flex-shrink: 0;
+}
+</style>

--- a/webapp/frontend/src/components/TreeNode.vue
+++ b/webapp/frontend/src/components/TreeNode.vue
@@ -9,9 +9,8 @@
       <span
         v-if="node.children.length"
         class="tree-node__caret"
-        :class="{ 'tree-node__caret--open': expanded }"
         @click.stop="expanded = !expanded"
-      >▸</span>
+      >{{ expanded ? '−' : '+' }}</span>
       <span v-else class="tree-node__caret tree-node__caret--leaf">·</span>
       <span class="tree-node__label">{{ node.label }}</span>
       <span class="tree-node__count">{{ node.count }}</span>
@@ -23,6 +22,7 @@
         :node="child"
         :depth="depth + 1"
         :selected-path="selectedPath"
+        :force-expand="node.children.length === 1"
         @select="$emit('select', $event)"
       />
     </div>
@@ -30,17 +30,20 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 const props = defineProps({
   node: Object,
   depth: { type: Number, default: 0 },
   selectedPath: String,
+  forceExpand: { type: Boolean, default: false },
 })
 defineEmits(['select'])
 
-// Top-level nodes start expanded; deeper ones collapsed.
-const expanded = ref(props.depth < 1)
+const expanded = ref(props.depth < 1 || props.forceExpand)
+
+// When the parent expands and has only one child, auto-expand this node too.
+watch(() => props.forceExpand, val => { if (val) expanded.value = true })
 </script>
 
 <style scoped>
@@ -54,7 +57,7 @@ const expanded = ref(props.depth < 1)
   border: none;
   text-align: left;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 15px;
   color: var(--text, #222);
   border-radius: 4px;
 }
@@ -66,19 +69,20 @@ const expanded = ref(props.depth < 1)
 .tree-node__row--selected .tree-node__count { color: rgba(255, 255, 255, 0.8); }
 
 .tree-node__caret {
-  width: 12px;
-  font-size: 10px;
+  width: 16px;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1;
+  text-align: center;
   color: #666;
-  transition: transform 0.15s;
   user-select: none;
   flex-shrink: 0;
 }
-.tree-node__caret--open { transform: rotate(90deg); }
-.tree-node__caret--leaf { color: #ccc; }
+.tree-node__caret--leaf { color: #ccc; font-weight: 400; }
 
 .tree-node__label { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .tree-node__count {
-  font-size: 11px;
+  font-size: 13px;
   color: #888;
   margin-left: 4px;
   flex-shrink: 0;

--- a/webapp/frontend/src/firebase.js
+++ b/webapp/frontend/src/firebase.js
@@ -2,16 +2,14 @@ import { initializeApp } from 'firebase/app'
 import { getAuth, GoogleAuthProvider, signInWithPopup, signOut, onIdTokenChanged } from 'firebase/auth'
 import { ref } from 'vue'
 
-// Fill these in after running `terraform apply` (see SETUP.md step 8).
-// Leave as-is for local development — auth will be skipped automatically.
 const firebaseConfig = {
   apiKey:    "AIzaSyA5CGlWuvCriQPUWk0l4CrER55tFvSz2Vc",
   authDomain: "trackcam-viewer.firebaseapp.com",
   projectId: "trackcam-viewer",
 }
 
-/** True only when real Firebase credentials have been configured. */
-export const AUTH_ENABLED = firebaseConfig.apiKey !== "REPLACE_WITH_YOUR_API_KEY"
+// Auth is skipped in local dev (`npm run dev`) and enabled in production builds.
+export const AUTH_ENABLED = import.meta.env.PROD
 
 const firebaseApp = initializeApp(firebaseConfig)
 const auth        = getAuth(firebaseApp)


### PR DESCRIPTION
## Summary
- New top-level view, toggled from the header, showing a species taxonomy tree on the left and species cards on the right
- Each card shows the common name, scientific name, detection count, and top 5 detection crops ranked by confidence then recency
- Tree is built from the semicolon-separated taxonomy in `prediction.raw` (kingdom → species)

## Test plan
- [x] Switch between Gallery and Species views via header tabs
- [x] Expand/collapse tree nodes; select nodes at different levels (order, family, species)
- [x] Verify card counts match tree counts; crops load and open ImageModal on click
- [x] Verify cards sort by detection count desc; crops sort by confidence desc

🤖 Generated with [Claude Code](https://claude.com/claude-code)