### PR TITLE
Always re-apply GPU config after inference job create or update

### DIFF
--- a/infra/deploy-inference.ps1
+++ b/infra/deploy-inference.ps1
@@ -16,4 +16,14 @@ Write-Host "==> Pushing inference image..."
 docker push $IMAGE
 if ($LASTEXITCODE -ne 0) { throw "docker push failed" }
 
-Write-Host "==> Done. Next job execution will use the new image."
+Write-Host "==> Updating job image and re-applying GPU config..."
+gcloud beta run jobs update speciesnet-inference `
+  --image $IMAGE `
+  --gpu=1 --gpu-type=nvidia-l4 `
+  --execution-environment=gen2 `
+  --no-gpu-zonal-redundancy `
+  --region us-east4 `
+  --project trackcam-viewer
+if ($LASTEXITCODE -ne 0) { throw "gcloud job update failed" }
+
+Write-Host "==> Done."

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -106,9 +106,13 @@ resource "google_cloud_run_v2_job" "inference" {
 }
 
 # node_selector (GPU config) is not yet in the Terraform provider schema.
-# Apply it via gcloud after the job is created/updated.
+# Apply it via gcloud after every job create or update so the GPU config
+# is never silently wiped by a Terraform in-place update.
 resource "terraform_data" "inference_gpu" {
-  triggers_replace = [google_cloud_run_v2_job.inference.id]
+  triggers_replace = [
+    google_cloud_run_v2_job.inference.id,
+    var.inference_image,
+  ]
 
   provisioner "local-exec" {
     command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --no-gpu-zonal-redundancy --region=${var.region} --project=${var.project_id}"

--- a/webapp/frontend/package-lock.json
+++ b/webapp/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "trailcam-viewer",
       "version": "0.1.0",
       "dependencies": {
+        "exifr": "^7.1.3",
         "firebase": "^10.0.0",
         "vue": "^3.4.0"
       },
@@ -1768,6 +1769,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
       "license": "MIT"
     },
     "node_modules/faye-websocket": {

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "exifr": "^7.1.3",
     "firebase": "^10.0.0",
     "vue": "^3.4.0"
   },

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -126,6 +126,18 @@
             </div>
           </section>
 
+          <!-- EXIF tags -->
+          <section v-if="exifEntries.length || exifLoading" class="panel__section">
+            <h3 class="panel__heading">EXIF</h3>
+            <div v-if="exifLoading" class="panel__exif-loading">Reading…</div>
+            <dl v-else class="panel__meta panel__exif">
+              <template v-for="[k, v] in exifEntries" :key="k">
+                <dt>{{ k }}</dt>
+                <dd>{{ v }}</dd>
+              </template>
+            </dl>
+          </section>
+
           <!-- Failures -->
           <section v-if="image.failures?.length" class="panel__section">
             <h3 class="panel__heading panel__heading--warn">Failures</h3>
@@ -139,6 +151,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import exifr from 'exifr'
 import DetectionCrop from './DetectionCrop.vue'
 import { imageUrl } from '../firebase.js'
 
@@ -166,6 +179,40 @@ const imageSrc = computed(() => {
 const significantDetections = computed(() =>
   (props.image.detections ?? []).filter(d => d.conf >= 0.1)
 )
+
+// ── EXIF tags ─────────────────────────────────────────────────────────────────
+const exifTags    = ref(null)
+const exifLoading = ref(false)
+
+const exifEntries = computed(() => {
+  if (!exifTags.value) return []
+  return Object.entries(exifTags.value)
+    .filter(([, v]) => v !== undefined && v !== null && v !== '')
+    .map(([k, v]) => [k, formatExifValue(v)])
+    .sort(([a], [b]) => a.localeCompare(b))
+})
+
+function formatExifValue(v) {
+  if (v instanceof Date) return v.toISOString().replace('T', ' ').slice(0, 19)
+  if (Array.isArray(v))  return v.map(formatExifValue).join(', ')
+  if (typeof v === 'number') return Number.isInteger(v) ? String(v) : v.toFixed(4)
+  if (typeof v === 'object') return JSON.stringify(v)
+  return String(v)
+}
+
+async function loadExif() {
+  exifTags.value = null
+  exifLoading.value = true
+  try {
+    const url = imageUrl(props.image.filepath)
+    const tags = await exifr.parse(url, { tiff: true, exif: true, gps: true, ifd0: true })
+    exifTags.value = tags || {}
+  } catch (e) {
+    exifTags.value = {}
+  } finally {
+    exifLoading.value = false
+  }
+}
 
 function getCategory(img) {
   const name = img.prediction?.common_name?.toLowerCase()
@@ -235,7 +282,8 @@ watch(() => props.image, () => {
   imageLoaded.value = false
   showPreview.value = false
   hasPreview.value = true
-})
+  loadExif()
+}, { immediate: true })
 </script>
 
 <style scoped>
@@ -529,5 +577,23 @@ watch(() => props.image, () => {
 .panel__failure {
   font-size: 12px;
   color: #f87171;
+}
+
+.panel__exif-loading {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.panel__exif {
+  grid-template-columns: minmax(90px, auto) 1fr;
+  font-size: 11px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+.panel__exif dd {
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 </style>


### PR DESCRIPTION
Terraform's local-exec now triggers on inference_image changes (not just resource recreation), and deploy-inference.ps1 explicitly sets GPU flags on every deploy so the config can't be silently wiped.