### PR TITLE
Delete images from gallery/modal; drop Annotated preview

### DIFF
--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -300,14 +300,46 @@ def get_image(path: str = Query(...)):
     return FileResponse(path, media_type="image/jpeg")
 
 
-@app.get("/api/preview")
-def get_preview(path: str = Query(...)):
+def _preview_path_for(path: str) -> str:
+    """Path where SpeciesNet's visualiser writes the annotated copy of `path`."""
     preview_dir = str(Path(path).parent / "previews")
     encoded = path.replace(":", "~").replace("/", "~").replace("\\", "~")
-    preview_path = os.path.join(preview_dir, f"anno_{encoded}")
-    if not os.path.isfile(preview_path):
-        raise HTTPException(status_code=404, detail="Preview not found")
-    return FileResponse(preview_path, media_type="image/jpeg")
+    return os.path.join(preview_dir, f"anno_{encoded}")
+
+
+@app.delete("/api/predictions")
+def delete_prediction(path: str = Query(..., description="Filepath of the image to delete")):
+    """Remove an image from predictions.json and delete its file + preview from disk."""
+    if not os.path.isfile(PREDICTIONS_FILE):
+        raise HTTPException(status_code=404, detail="Predictions file not found")
+
+    with open(PREDICTIONS_FILE, encoding="utf-8") as f:
+        data = json.load(f)
+
+    target = _norm_path(path)
+    kept, removed = [], []
+    for p in data.get("predictions", []):
+        if _norm_path(p.get("filepath", "")) == target:
+            removed.append(p)
+        else:
+            kept.append(p)
+
+    if not removed:
+        raise HTTPException(status_code=404, detail="No prediction found for that path")
+
+    data["predictions"] = kept
+    with open(PREDICTIONS_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=1)
+
+    # Only delete disk files that were actually listed in predictions.json
+    for fp in (removed[0]["filepath"], _preview_path_for(removed[0]["filepath"])):
+        try:
+            if os.path.isfile(fp):
+                os.unlink(fp)
+        except OSError:
+            pass
+
+    return {"deleted": True, "path": path, "removed_entries": len(removed)}
 
 
 # ---------------------------------------------------------------------------

--- a/webapp/backend/main_cloud.py
+++ b/webapp/backend/main_cloud.py
@@ -110,6 +110,39 @@ async def get_predictions(uid: str = Depends(verify_token)):
     return {"predictions": predictions}
 
 
+@app.delete("/api/predictions")
+async def delete_prediction(
+    path: str = Query(..., description="GCS object path of the image to delete"),
+    uid: str = Depends(verify_token),
+):
+    """Delete a prediction doc, its source image, and any detection crops."""
+    if not path.startswith(f"images/{uid}/"):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    doc_id  = hashlib.md5(path.encode()).hexdigest()
+    doc_ref = _db.collection("users").document(uid).collection("predictions").document(doc_id)
+    snap    = doc_ref.get()
+
+    crop_paths: list[str] = []
+    if snap.exists:
+        for det in (snap.to_dict().get("detections") or []):
+            crop = det.get("crop_gcs_path")
+            if crop and crop.startswith(f"crops/{uid}/"):
+                crop_paths.append(crop)
+
+    for blob_path in [path, *crop_paths]:
+        try:
+            _bucket.blob(blob_path).delete()
+        except Exception:
+            # Blob already missing — continue so we still clean up Firestore
+            pass
+
+    if snap.exists:
+        doc_ref.delete()
+
+    return {"deleted": True, "path": path, "crops_deleted": len(crop_paths)}
+
+
 # ── Image serving (signed URL redirect) ───────────────────────────────────────
 
 @app.get("/api/image")

--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -73,6 +73,7 @@
             :events="groupedEvents"
             @select="openModal"
             @day-select="selectedDay = $event"
+            @delete="requestDelete"
           />
         </template>
         <SpeciesView
@@ -90,6 +91,7 @@
       :all-images="filteredPredictions"
       @close="selectedImage = null"
       @navigate="openModal"
+      @deleted="onImageDeleted"
     />
 
     <DaySummary
@@ -103,6 +105,28 @@
       @close="showProcess = false"
       @done="onProcessDone"
     />
+
+    <!-- Gallery-tile delete confirmation -->
+    <div
+      v-if="pendingDelete"
+      class="confirm-backdrop"
+      @click.self="cancelDelete"
+    >
+      <div class="confirm">
+        <h3 class="confirm__title">Delete this image?</h3>
+        <p class="confirm__body">
+          <strong>{{ pendingDelete.filename }}</strong> and any cropped versions
+          will be permanently removed from storage. This cannot be undone.
+        </p>
+        <p v-if="deleteError" class="confirm__error">{{ deleteError }}</p>
+        <div class="confirm__actions">
+          <button class="confirm__btn" :disabled="deleting" @click="cancelDelete">Cancel</button>
+          <button class="confirm__btn confirm__btn--danger" :disabled="deleting" @click="doDelete">
+            {{ deleting ? 'Deleting…' : 'Delete' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- Auth initialising -->
@@ -262,6 +286,50 @@ function filenameToDate(filename) {
 }
 
 function openModal(image) { selectedImage.value = image }
+
+function onImageDeleted(image) {
+  const remaining = filteredPredictions.value
+  const idx       = remaining.indexOf(image)
+  const next      = remaining[idx + 1] ?? remaining[idx - 1] ?? null
+  predictions.value = predictions.value.filter(p => p !== image)
+  selectedImage.value = next && next !== image ? next : null
+}
+
+// ── Gallery-tile delete ───────────────────────────────────────────────────────
+const pendingDelete = ref(null)
+const deleting      = ref(false)
+const deleteError   = ref('')
+
+function requestDelete(image) {
+  pendingDelete.value = image
+  deleteError.value   = ''
+}
+
+function cancelDelete() {
+  if (deleting.value) return
+  pendingDelete.value = null
+  deleteError.value   = ''
+}
+
+async function doDelete() {
+  const image = pendingDelete.value
+  if (!image) return
+  deleting.value = true
+  deleteError.value = ''
+  try {
+    const res = await apiFetch(
+      `/api/predictions?path=${encodeURIComponent(image.filepath)}`,
+      { method: 'DELETE' },
+    )
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    predictions.value  = predictions.value.filter(p => p !== image)
+    pendingDelete.value = null
+  } catch (e) {
+    deleteError.value = `Delete failed: ${e.message}`
+  } finally {
+    deleting.value = false
+  }
+}
 
 function applyHistogramFilter({ species, hour }) {
   filters.species = species
@@ -492,4 +560,80 @@ onMounted(() => {
 }
 
 .state-msg--error { color: #f87171; }
+
+/* ── Confirmation dialog (gallery-tile delete) ────────────────────────────── */
+.confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  padding: 16px;
+}
+
+.confirm {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.confirm__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.confirm__body {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.confirm__body strong { color: var(--text); }
+
+.confirm__error {
+  margin: 0;
+  font-size: 12px;
+  color: #f87171;
+}
+
+.confirm__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.confirm__btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.confirm__btn:hover:not(:disabled) { background: var(--surface); }
+.confirm__btn:disabled { opacity: 0.5; cursor: default; }
+
+.confirm__btn--danger {
+  background: #7f1d1d;
+  border-color: #b91c1c;
+  color: #fee2e2;
+}
+
+.confirm__btn--danger:hover:not(:disabled) {
+  background: #991b1b;
+}
 </style>

--- a/webapp/frontend/src/components/ImageGallery.vue
+++ b/webapp/frontend/src/components/ImageGallery.vue
@@ -9,25 +9,39 @@
       </div>
 
       <!-- Individual image cells flow into the grid -->
-      <button
+      <div
         v-for="img in event.images"
         :key="img.filename"
-        class="gallery__thumb"
-        @click="$emit('select', img)"
+        class="gallery__tile"
       >
-        <img
-          :src="imageUrl(img.filepath)"
-          :alt="img.filename"
-          loading="lazy"
-        />
-        <div class="gallery__badge-row">
-          <span
-            v-for="det in detectionCounts(img)"
-            :key="det.label"
-            :class="`badge badge--${det.label}`"
-          >{{ det.label +": " }} {{ det.count}} </span>
-        </div>
-      </button>
+        <button
+          class="gallery__thumb"
+          @click="$emit('select', img)"
+        >
+          <img
+            :src="imageUrl(img.filepath)"
+            :alt="img.filename"
+            loading="lazy"
+          />
+          <div class="gallery__badge-row">
+            <span
+              v-for="det in detectionCounts(img)"
+              :key="det.label"
+              :class="`badge badge--${det.label}`"
+            >{{ det.label +": " }} {{ det.count}} </span>
+          </div>
+        </button>
+        <button
+          class="gallery__delete"
+          title="Delete image"
+          @click.stop="$emit('delete', img)"
+        >
+          <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6Z"/>
+            <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1ZM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118ZM2.5 3h11V2h-11v1Z"/>
+          </svg>
+        </button>
+      </div>
     </template>
   </div>
 </template>
@@ -35,7 +49,7 @@
 <script setup>
 import { imageUrl } from '../firebase.js'
 const props = defineProps({ events: Array })
-defineEmits(['select', 'day-select'])
+defineEmits(['select', 'day-select', 'delete'])
 
 function dayData(event) {
   const dayPrefix = event.timestamp.substring(0, 8)
@@ -123,6 +137,14 @@ function detectionCounts(img) {
   color: var(--text-muted);
 }
 
+.gallery__tile {
+  position: relative;
+}
+
+.gallery__tile:hover .gallery__delete {
+  opacity: 1;
+}
+
 .gallery__thumb {
   position: relative;
   aspect-ratio: 4/3;
@@ -133,10 +155,46 @@ function detectionCounts(img) {
   padding: 0;
   cursor: pointer;
   transition: opacity 0.15s;
+  width: 100%;
+  display: block;
 }
 
 .gallery__thumb:hover {
   opacity: 0.85;
+}
+
+.gallery__delete {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(153, 27, 27, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  color: #fff;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+  z-index: 2;
+}
+
+.gallery__delete:focus,
+.gallery__tile:focus-within .gallery__delete {
+  opacity: 1;
+}
+
+.gallery__delete:hover {
+  background: #b91c1c;
+}
+
+.gallery__delete svg {
+  width: 15px;
+  height: 15px;
 }
 
 .gallery__thumb img {

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -7,12 +7,30 @@
         <span class="modal__filename">{{ image.filename }}</span>
         <div class="modal__toolbar-right">
           <button
-            :class="['modal__toggle', { active: showPreview }]"
-            :disabled="!hasPreview"
-            :title="hasPreview ? 'Toggle annotated preview' : 'No preview available'"
-            @click="togglePreview"
-          >Annotated</button>
+            class="modal__delete"
+            :disabled="deleting"
+            title="Delete image"
+            @click="confirmingDelete = true"
+          >Delete</button>
           <button class="modal__close" @click="$emit('close')">✕</button>
+        </div>
+      </div>
+
+      <!-- Delete confirmation overlay -->
+      <div v-if="confirmingDelete" class="confirm-backdrop" @click.self="cancelDelete">
+        <div class="confirm">
+          <h3 class="confirm__title">Delete this image?</h3>
+          <p class="confirm__body">
+            <strong>{{ image.filename }}</strong> and any cropped versions will be
+            permanently removed from storage. This cannot be undone.
+          </p>
+          <p v-if="deleteError" class="confirm__error">{{ deleteError }}</p>
+          <div class="confirm__actions">
+            <button class="confirm__btn" :disabled="deleting" @click="cancelDelete">Cancel</button>
+            <button class="confirm__btn confirm__btn--danger" :disabled="deleting" @click="doDelete">
+              {{ deleting ? 'Deleting…' : 'Delete' }}
+            </button>
+          </div>
         </div>
       </div>
 
@@ -23,14 +41,13 @@
           <div class="modal__canvas-container" ref="containerRef">
             <img
               ref="imgRef"
-              :src="imageSrc"
+              :src="imageUrl(image.filepath)"
               :alt="image.filename"
               class="modal__img"
               @load="onImageLoad"
-              @error="onImageError"
             />
             <!-- Bbox overlays — rendered after image loads -->
-            <template v-if="imageLoaded && !showPreview">
+            <template v-if="imageLoaded">
               <div
                 v-for="(det, i) in significantDetections"
                 :key="i"
@@ -56,7 +73,7 @@
           <DetectionCrop
             v-for="(det, i) in significantDetections"
             :key="i"
-            :image-src="imageSrc"
+            :image-src="imageUrl(image.filepath)"
             :det="det"
             :color="categoryColor(det.category)"
           />
@@ -153,28 +170,48 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import exifr from 'exifr'
 import DetectionCrop from './DetectionCrop.vue'
-import { imageUrl } from '../firebase.js'
+import { imageUrl, apiFetch } from '../firebase.js'
 
 const props = defineProps({
   image: Object,
   allImages: Array,
 })
-const emit = defineEmits(['close', 'navigate'])
+const emit = defineEmits(['close', 'navigate', 'deleted'])
+
+const confirmingDelete = ref(false)
+const deleting         = ref(false)
+const deleteError      = ref('')
+
+function cancelDelete() {
+  if (deleting.value) return
+  confirmingDelete.value = false
+  deleteError.value = ''
+}
+
+async function doDelete() {
+  deleting.value = true
+  deleteError.value = ''
+  try {
+    const res = await apiFetch(
+      `/api/predictions?path=${encodeURIComponent(props.image.filepath)}`,
+      { method: 'DELETE' },
+    )
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const deletedImage = props.image
+    confirmingDelete.value = false
+    emit('deleted', deletedImage)
+  } catch (e) {
+    deleteError.value = `Delete failed: ${e.message}`
+  } finally {
+    deleting.value = false
+  }
+}
 
 const imgRef = ref(null)
 const containerRef = ref(null)
 const imageLoaded = ref(false)
-const showPreview = ref(false)
-const hasPreview = ref(true)
 
 const currentIndex = computed(() => props.allImages.indexOf(props.image))
-
-const imageSrc = computed(() => {
-  if (showPreview.value) {
-    return `/api/preview?path=${encodeURIComponent(props.image.filepath)}`
-  }
-  return imageUrl(props.image.filepath)
-})
 
 const significantDetections = computed(() =>
   (props.image.detections ?? []).filter(d => d.conf >= 0.1)
@@ -247,30 +284,21 @@ function onImageLoad() {
   imageLoaded.value = true
 }
 
-function onImageError() {
-  if (showPreview.value) {
-    hasPreview.value = false
-    showPreview.value = false
-  }
-}
-
-function togglePreview() {
-  imageLoaded.value = false
-  showPreview.value = !showPreview.value
-}
-
 function navigate(delta) {
   const next = props.allImages[currentIndex.value + delta]
   if (next) {
     imageLoaded.value = false
-    showPreview.value = false
-    hasPreview.value = true
     emit('navigate', next)
   }
 }
 
 function onKeydown(e) {
-  if (e.key === 'Escape') emit('close')
+  if (e.key === 'Escape') {
+    if (confirmingDelete.value) cancelDelete()
+    else emit('close')
+    return
+  }
+  if (confirmingDelete.value) return
   if (e.key === 'ArrowLeft')  navigate(-1)
   if (e.key === 'ArrowRight') navigate(1)
 }
@@ -280,8 +308,8 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 
 watch(() => props.image, () => {
   imageLoaded.value = false
-  showPreview.value = false
-  hasPreview.value = true
+  confirmingDelete.value = false
+  deleteError.value = ''
   loadExif()
 }, { immediate: true })
 </script>
@@ -331,26 +359,6 @@ watch(() => props.image, () => {
   gap: 8px;
 }
 
-.modal__toggle {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text-muted);
-  padding: 4px 10px;
-  font-size: 12px;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.modal__toggle.active {
-  border-color: var(--animal);
-  color: var(--animal);
-}
-
-.modal__toggle:disabled {
-  opacity: 0.35;
-  cursor: default;
-}
-
 .modal__close {
   background: none;
   border: 1px solid var(--border);
@@ -365,6 +373,99 @@ watch(() => props.image, () => {
 }
 
 .modal__close:hover { color: var(--text); }
+
+.modal__delete {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  padding: 4px 10px;
+  font-size: 12px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.modal__delete:hover:not(:disabled) {
+  color: #fca5a5;
+  border-color: #b91c1c;
+  background: rgba(185, 28, 28, 0.12);
+}
+
+.modal__delete:disabled { opacity: 0.5; cursor: default; }
+
+/* Confirmation overlay */
+.confirm-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.confirm {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+  width: min(420px, calc(100% - 32px));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.confirm__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.confirm__body {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.confirm__body strong { color: var(--text); }
+
+.confirm__error {
+  margin: 0;
+  font-size: 12px;
+  color: #f87171;
+}
+
+.confirm__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.confirm__btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.confirm__btn:hover:not(:disabled) { background: var(--surface); }
+.confirm__btn:disabled { opacity: 0.5; cursor: default; }
+
+.confirm__btn--danger {
+  background: #7f1d1d;
+  border-color: #b91c1c;
+  color: #fee2e2;
+}
+
+.confirm__btn--danger:hover:not(:disabled) {
+  background: #991b1b;
+}
 
 .modal__body {
   display: flex;


### PR DESCRIPTION
## Summary

- Adds a delete-image flow from two entry points: a red trash button on each gallery tile (upper-right, hover-reveal) and a Delete button in the `ImageModal` toolbar. Both show a styled confirmation dialog before acting.
- Implements `DELETE /api/predictions?path=…` on both backends. Cloud deletes the Firestore prediction doc, the source image blob, and every `crop_gcs_path` blob referenced by the doc's detections. Local removes the entry from `predictions.json` and unlinks the source file plus its annotated preview from disk.
- Removes the Annotated preview feature (button + client state + `GET /api/preview`). Those preview files came from SpeciesNet's external visualiser and existed for only ~15% of images in practice, so the toggle usually appeared to do nothing. The bbox overlays in the modal already provide the same information. Kept `_preview_path_for` so delete still cleans up orphan preview files from past visualiser runs.

## Notes for reviewers

- Cloud `DELETE` authorises via the existing `verify_token` dep and refuses paths that don't start with `images/{uid}/`. Crop deletion is best-effort — missing blobs are ignored so Firestore still gets cleaned up.
- Local `DELETE` only unlinks filepaths that were actually in `predictions.json`, so passing an arbitrary path won't nuke unrelated files.
- After a successful delete, the modal auto-advances to the next filtered image (or closes if it was the last). Gallery deletes just remove the tile in place.
- HTML: gallery tile was changed from a single `<button>` to a wrapper `<div>` containing the thumb button and a sibling delete button, so we don't nest buttons.

## Test plan

- [x] Local mode: delete an image from a gallery tile — confirm, then verify the row/tile disappears, `predictions.json` no longer contains it, and the source + `previews/anno_…` files are gone from disk.
- [x] Local mode: delete from the modal — confirm, then verify modal advances to next image; delete the last image and verify modal closes.
- [x] Cloud mode: delete an image — verify the Firestore doc under `users/{uid}/predictions/{md5(gcs_path)}` is removed, the image blob under `images/{uid}/…` is gone, and every crop under `crops/{uid}/…` referenced by that doc is gone.
- [x] Cloud mode: try calling `DELETE /api/predictions?path=images/other-uid/…` as a different user and confirm 403.
- [x] Cancel button and Escape key both dismiss the confirmation without deleting.
- [x] Modal no longer shows the Annotated button; bbox overlays still appear on top of the raw image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)