### PR TITLE
Add image deletion, species bbox labels, and fix bbox alignment

### DIFF
--- a/webapp/frontend/src/components/DetectionCrop.vue
+++ b/webapp/frontend/src/components/DetectionCrop.vue
@@ -4,11 +4,11 @@
       v-if="det.crop_gcs_path"
       :src="imageUrl(det.crop_gcs_path)"
       class="crop__img"
-      :alt="det.label"
+      :alt="label"
     />
     <canvas v-else ref="canvasRef" class="crop__canvas" />
     <span class="crop__badge" :style="{ background: color }">
-      {{ det.label }} {{ (det.conf * 100).toFixed(0) }}%
+      {{ label }} {{ (det.conf * 100).toFixed(0) }}%
     </span>
   </div>
 </template>
@@ -21,6 +21,7 @@ const props = defineProps({
   imageSrc: String,
   det: Object,
   color: String,
+  label: String,
 })
 
 const canvasRef = ref(null)

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -37,8 +37,12 @@
       <div class="modal__body">
         <div class="modal__left">
         <!-- Image + bbox overlay -->
-        <div class="modal__image-wrap">
-          <div class="modal__canvas-container" ref="containerRef">
+        <div class="modal__image-wrap" ref="wrapRef">
+          <div
+            class="modal__canvas-container"
+            ref="containerRef"
+            :style="containerStyle"
+          >
             <img
               ref="imgRef"
               :src="imageUrl(image.filepath)"
@@ -53,10 +57,10 @@
                 :key="i"
                 class="modal__bbox"
                 :style="bboxStyle(det)"
-                :title="`${det.label} ${(det.conf * 100).toFixed(0)}%`"
+                :title="`${detectionLabel(det)} ${(det.conf * 100).toFixed(0)}%`"
               >
                 <span class="modal__bbox-label" :style="{ background: categoryColor(det.category) }">
-                  {{ det.label }} {{ (det.conf * 100).toFixed(0) }}%
+                  {{ detectionLabel(det) }} {{ (det.conf * 100).toFixed(0) }}%
                 </span>
               </div>
             </template>
@@ -76,6 +80,7 @@
             :image-src="imageUrl(image.filepath)"
             :det="det"
             :color="categoryColor(det.category)"
+            :label="detectionLabel(det)"
           />
         </div>
         </div><!-- end .modal__left -->
@@ -137,7 +142,7 @@
             <div class="panel__detections">
               <div v-for="(det, i) in significantDetections" :key="i" class="panel__det">
                 <span class="panel__det-dot" :style="{ background: categoryColor(det.category) }"></span>
-                <span>{{ capitalize(det.label) }}</span>
+                <span>{{ detectionLabel(det) }}</span>
                 <span class="panel__det-conf">{{ (det.conf * 100).toFixed(0) }}%</span>
               </div>
             </div>
@@ -209,7 +214,10 @@ async function doDelete() {
 
 const imgRef = ref(null)
 const containerRef = ref(null)
+const wrapRef = ref(null)
 const imageLoaded = ref(false)
+const containerStyle = ref(null)
+let resizeObserver = null
 
 const currentIndex = computed(() => props.allImages.indexOf(props.image))
 
@@ -269,6 +277,20 @@ function categoryColor(cat) {
   return CATEGORY_COLORS[cat] ?? '#a78bfa'
 }
 
+const NON_SPECIES = new Set(['blank', 'human', 'vehicle'])
+
+function detectionLabel(det) {
+  // For animal detections, show the image's species prediction when it's
+  // an actual species (not a blank/human/vehicle classifier fallback).
+  if (det.category === '1') {
+    const name = props.image.prediction?.common_name
+    if (name && !NON_SPECIES.has(name.toLowerCase())) {
+      return capitalize(name)
+    }
+  }
+  return capitalize(det.label)
+}
+
 function bboxStyle(det) {
   const [x, y, w, h] = det.bbox
   return {
@@ -280,8 +302,25 @@ function bboxStyle(det) {
   }
 }
 
+function computeContainerSize() {
+  const img = imgRef.value
+  const wrap = wrapRef.value
+  if (!img || !wrap || !img.naturalWidth || !img.naturalHeight) return
+  const maxW = wrap.clientWidth
+  const maxH = wrap.clientHeight
+  const ar = img.naturalWidth / img.naturalHeight
+  let w = maxW
+  let h = w / ar
+  if (h > maxH) {
+    h = maxH
+    w = h * ar
+  }
+  containerStyle.value = { width: `${w}px`, height: `${h}px` }
+}
+
 function onImageLoad() {
   imageLoaded.value = true
+  computeContainerSize()
 }
 
 function navigate(delta) {
@@ -303,11 +342,21 @@ function onKeydown(e) {
   if (e.key === 'ArrowRight') navigate(1)
 }
 
-onMounted(() => window.addEventListener('keydown', onKeydown))
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+onMounted(() => {
+  window.addEventListener('keydown', onKeydown)
+  if (wrapRef.value && 'ResizeObserver' in window) {
+    resizeObserver = new ResizeObserver(() => computeContainerSize())
+    resizeObserver.observe(wrapRef.value)
+  }
+})
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKeydown)
+  resizeObserver?.disconnect()
+})
 
 watch(() => props.image, () => {
   imageLoaded.value = false
+  containerStyle.value = null
   confirmingDelete.value = false
   deleteError.value = ''
   loadExif()
@@ -506,16 +555,13 @@ watch(() => props.image, () => {
 
 .modal__canvas-container {
   position: relative;
-  display: inline-flex;
-  max-width: 100%;
-  max-height: 100%;
+  display: block;
 }
 
 .modal__img {
   display: block;
-  max-width: 100%;
-  max-height: calc(100vh - 160px);
-  object-fit: contain;
+  width: 100%;
+  height: 100%;
 }
 
 .modal__bbox {

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -7,6 +7,12 @@
         <span class="modal__filename">{{ image.filename }}</span>
         <div class="modal__toolbar-right">
           <button
+            class="modal__toggle"
+            :class="{ 'modal__toggle--off': !showBoxes }"
+            :title="showBoxes ? 'Hide bounding boxes' : 'Show bounding boxes'"
+            @click="showBoxes = !showBoxes"
+          >{{ showBoxes ? 'Hide boxes' : 'Show boxes' }}</button>
+          <button
             class="modal__delete"
             :disabled="deleting"
             title="Delete image"
@@ -51,7 +57,7 @@
               @load="onImageLoad"
             />
             <!-- Bbox overlays — rendered after image loads -->
-            <template v-if="imageLoaded">
+            <template v-if="imageLoaded && showBoxes">
               <div
                 v-for="(det, i) in significantDetections"
                 :key="i"
@@ -186,6 +192,7 @@ const emit = defineEmits(['close', 'navigate', 'deleted'])
 const confirmingDelete = ref(false)
 const deleting         = ref(false)
 const deleteError      = ref('')
+const showBoxes        = ref(true)
 
 function cancelDelete() {
   if (deleting.value) return
@@ -423,6 +430,7 @@ watch(() => props.image, () => {
 
 .modal__close:hover { color: var(--text); }
 
+.modal__toggle,
 .modal__delete {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -431,6 +439,15 @@ watch(() => props.image, () => {
   padding: 4px 10px;
   font-size: 12px;
   transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.modal__toggle:hover {
+  color: var(--text);
+}
+
+.modal__toggle--off {
+  color: var(--text);
+  background: var(--surface2);
 }
 
 .modal__delete:hover:not(:disabled) {


### PR DESCRIPTION
## Summary

- **Delete images from gallery and modal** — red trash button on each gallery tile and a Delete button in the image modal toolbar. Both open a confirmation dialog and, on confirm, remove the source image plus any cropped versions from storage (GCS buckets in cloud mode, local files + `predictions.json` entry locally). The modal advances to the next image after a successful delete.
- **Drop the "Annotated" button** — it relied on preview files written by SpeciesNet's external visualizer, which aren't generated anywhere in this repo. Most images had no preview, so the button silently did nothing. Removed the UI plus the now-unused `/api/preview` GET endpoint; kept `_preview_path_for` in the local backend so deletes still clean up any stray previews.
- **Species labels on bbox overlays and crops** — for category-1 (animal) detections, the bbox overlay, detection crop badge, and side-panel detection list now show the image's predicted species (e.g. "White-tailed deer") instead of "Animal". Falls back to the raw label when the prediction is blank/human/vehicle.
- **Fix bbox misalignment** — overlays were drifting outward symmetrically (left boxes shifted left, right boxes shifted right) because the canvas container used `display: inline-flex` with default `align-items: stretch`, giving the img an element box with a different aspect-ratio than its pixels; `object-fit: contain` then letterboxed inside it. Now JS computes the container's exact render box from the wrap's dimensions and the image's natural aspect-ratio, the img fills 100%/100% of it, and a ResizeObserver keeps it in sync.

## Test plan

- [x] Open an image in the modal, click Delete, confirm — verify the image and its crop files disappear from the bucket / local filesystem and the modal advances to the next image.
- [x] Hover a gallery tile, click the trash icon, confirm — verify the tile disappears and the image is gone from storage.
- [x] Cancel a delete from both entry points — verify nothing is deleted.
- [x] Open an image with a species prediction and check that the bbox overlay, detection crop at the bottom, and side-panel detection list all show the species name, not "Animal".
- [x] Open an image classified as blank/human/vehicle and verify the fallback label renders correctly.
- [x] Open images of various aspect-ratios (wide, tall, square) in the modal and resize the viewport — verify bboxes stay pinned to their objects with no horizontal or vertical drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)