### PR TITLE
Use EXIF DateTimeOriginal for gallery grouping

### DIFF
--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -23,6 +23,42 @@ CROP_CONF_THRESHOLD = 0.2
 CROP_MAX_DIM        = 512
 CROP_JPEG_QUALITY   = 85
 
+_EXIF_EXIF_IFD           = 0x8769
+_EXIF_DATETIME_ORIGINAL  = 0x9003
+_EXIF_DATETIME_DIGITIZED = 0x9004
+_EXIF_DATETIME           = 0x0132
+
+
+def _parse_exif_datetime(raw) -> str | None:
+    """Parse EXIF datetime string ('YYYY:MM:DD HH:MM:SS') to naive ISO."""
+    if not raw:
+        return None
+    try:
+        s = raw.strip() if isinstance(raw, str) else str(raw).strip()
+        return datetime.strptime(s, "%Y:%m:%d %H:%M:%S").isoformat()
+    except Exception:
+        return None
+
+
+def _extract_taken_at(path: str) -> str | None:
+    """Return naive-ISO datetime from EXIF DateTimeOriginal, or None."""
+    try:
+        with Image.open(path) as img:
+            exif = img.getexif()
+            if not exif:
+                return None
+            try:
+                sub = exif.get_ifd(_EXIF_EXIF_IFD)
+            except Exception:
+                sub = {}
+            for tag in (_EXIF_DATETIME_ORIGINAL, _EXIF_DATETIME_DIGITIZED):
+                parsed = _parse_exif_datetime(sub.get(tag))
+                if parsed:
+                    return parsed
+            return _parse_exif_datetime(exif.get(_EXIF_DATETIME))
+    except Exception:
+        return None
+
 # ── ANSI / tqdm helpers (same as local backend) ───────────────────────────────
 _ANSI_ESCAPE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07|\r')
 _TQDM_RE = re.compile(r'^(.+?)\s*:\s*(\d+)%\|[^|]*\|\s*(\d+)/(\d+)')
@@ -233,6 +269,7 @@ def main():
                 "filename":          filename,
                 "folder":            folder,
                 "uid":               uid,
+                "taken_at":          _extract_taken_at(local_fp),
                 "prediction":        prediction_label,
                 "prediction_score":  pred.get("prediction_score"),
                 "prediction_source": pred.get("prediction_source"),

--- a/infra/scripts/backfill_taken_at.py
+++ b/infra/scripts/backfill_taken_at.py
@@ -1,0 +1,115 @@
+"""
+Backfill `taken_at` on prediction docs from EXIF DateTimeOriginal.
+
+Reads each prediction's image from GCS, extracts the EXIF capture time
+(falling back to DigitizedTime, then the IFD0 DateTime), and writes it
+onto the Firestore doc as ISO 8601 naive-local.
+
+Environment:
+  GCP_PROJECT, GCS_BUCKET.
+  Google ADC with Firestore + GCS read/write.
+
+Usage:
+  python infra/scripts/backfill_taken_at.py [--uid UID] [--dry-run] [--overwrite]
+"""
+import argparse
+import io
+import os
+from datetime import datetime
+
+from google.cloud import firestore, storage
+from PIL import Image
+
+_EXIF_EXIF_IFD           = 0x8769
+_EXIF_DATETIME_ORIGINAL  = 0x9003
+_EXIF_DATETIME_DIGITIZED = 0x9004
+_EXIF_DATETIME           = 0x0132
+
+
+def _parse_exif_datetime(raw) -> str | None:
+    if not raw:
+        return None
+    try:
+        s = raw.strip() if isinstance(raw, str) else str(raw).strip()
+        return datetime.strptime(s, "%Y:%m:%d %H:%M:%S").isoformat()
+    except Exception:
+        return None
+
+
+def _extract_taken_at_from_bytes(data: bytes) -> str | None:
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            exif = img.getexif()
+            if not exif:
+                return None
+            try:
+                sub = exif.get_ifd(_EXIF_EXIF_IFD)
+            except Exception:
+                sub = {}
+            for tag in (_EXIF_DATETIME_ORIGINAL, _EXIF_DATETIME_DIGITIZED):
+                parsed = _parse_exif_datetime(sub.get(tag))
+                if parsed:
+                    return parsed
+            return _parse_exif_datetime(exif.get(_EXIF_DATETIME))
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--uid", help="Only backfill this user's predictions")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--overwrite", action="store_true",
+                    help="Re-extract even when taken_at is already set")
+    args = ap.parse_args()
+
+    project     = os.environ["GCP_PROJECT"]
+    bucket_name = os.environ["GCS_BUCKET"]
+
+    db     = firestore.Client(project=project)
+    gcs    = storage.Client(project=project)
+    bucket = gcs.bucket(bucket_name)
+
+    if args.uid:
+        user_refs = [db.collection("users").document(args.uid)]
+    else:
+        user_refs = list(db.collection("users").list_documents())
+
+    total = updated = skipped = no_exif = errors = 0
+
+    for user_ref in user_refs:
+        uid = user_ref.id
+        for doc in user_ref.collection("predictions").stream():
+            total += 1
+            data = doc.to_dict()
+            if data.get("taken_at") and not args.overwrite:
+                skipped += 1
+                continue
+            gcs_path = data.get("gcs_path") or data.get("filepath")
+            if not gcs_path:
+                print(f"[err]  {uid}/{doc.id}: no gcs_path")
+                errors += 1
+                continue
+            try:
+                blob_bytes = bucket.blob(gcs_path).download_as_bytes()
+            except Exception as exc:
+                print(f"[err]  {uid}/{gcs_path}: download failed: {exc}")
+                errors += 1
+                continue
+            taken_at = _extract_taken_at_from_bytes(blob_bytes)
+            if not taken_at:
+                no_exif += 1
+                print(f"[skip] {uid}/{gcs_path}: no EXIF date")
+                continue
+            print(f"[ok]   {uid}/{gcs_path}: {taken_at}")
+            if not args.dry_run:
+                doc.reference.update({"taken_at": taken_at})
+            updated += 1
+
+    suffix = " (dry-run)" if args.dry_run else ""
+    print(f"\nDone: total={total} updated={updated} already_set={skipped} "
+          f"no_exif={no_exif} errors={errors}{suffix}")
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -6,8 +6,45 @@ import sys
 import tempfile
 import threading
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+from PIL import Image
+
+_EXIF_EXIF_IFD           = 0x8769
+_EXIF_DATETIME_ORIGINAL  = 0x9003
+_EXIF_DATETIME_DIGITIZED = 0x9004
+_EXIF_DATETIME           = 0x0132
+
+
+def _parse_exif_datetime(raw) -> Optional[str]:
+    if not raw:
+        return None
+    try:
+        s = raw.strip() if isinstance(raw, str) else str(raw).strip()
+        return datetime.strptime(s, "%Y:%m:%d %H:%M:%S").isoformat()
+    except Exception:
+        return None
+
+
+def _extract_taken_at(path: str) -> Optional[str]:
+    try:
+        with Image.open(path) as img:
+            exif = img.getexif()
+            if not exif:
+                return None
+            try:
+                sub = exif.get_ifd(_EXIF_EXIF_IFD)
+            except Exception:
+                sub = {}
+            for tag in (_EXIF_DATETIME_ORIGINAL, _EXIF_DATETIME_DIGITIZED):
+                parsed = _parse_exif_datetime(sub.get(tag))
+                if parsed:
+                    return parsed
+            return _parse_exif_datetime(exif.get(_EXIF_DATETIME))
+    except Exception:
+        return None
 
 # Regex that matches ANSI escape sequences (colors, cursor moves, etc.)
 _ANSI_ESCAPE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07|\r')
@@ -105,6 +142,7 @@ def load_predictions() -> list:
         result.append({
             "filepath": filepath,
             "filename": filename,
+            "taken_at": _extract_taken_at(filepath),
             "prediction": prediction_label,
             "prediction_score": pred.get("prediction_score"),
             "prediction_source": pred.get("prediction_source"),

--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -205,7 +205,7 @@ async function loadPredictions() {
 }
 
 function _updateDateBounds(preds) {
-  const dates = preds.map(p => filenameToDate(p.filename)).filter(Boolean).sort()
+  const dates = preds.map(predDate).filter(Boolean).sort()
   if (dates.length) {
     dataDateFrom.value = dates[0]
     dataDateTo.value   = dates[dates.length - 1]
@@ -236,13 +236,12 @@ const filteredPredictions = computed(() => {
     if (filters.species && p.prediction?.common_name !== filters.species) return false
     if (filters.minConfidence > 0 && (p.prediction_score ?? 0) < filters.minConfidence / 100) return false
     if (filters.hour !== null) {
-      const ts = p.captured_at || p.filename || ''
-      const h = ts.length >= 10 ? parseInt(ts.slice(8, 10), 10) : -1
+      const h = predHour(p)
       if (h !== filters.hour) return false
     }
     if (from || to) {
-      const ts   = p.filename.substring(0, 8)
-      const date = `${ts.slice(0,4)}-${ts.slice(4,6)}-${ts.slice(6,8)}`
+      const date = predDate(p)
+      if (!date) return false
       if (from && date < from) return false
       if (to   && date > to)   return false
     }
@@ -253,7 +252,8 @@ const filteredPredictions = computed(() => {
 const groupedEvents = computed(() => {
   const groups = new Map()
   for (const pred of filteredPredictions.value) {
-    const ts = pred.filename.substring(0, 14)
+    const ts = predTs(pred)
+    if (!ts) continue
     if (!groups.has(ts)) groups.set(ts, [])
     groups.get(ts).push(pred)
   }
@@ -274,15 +274,30 @@ const stats = computed(() => ({
 }))
 
 function parseTimestamp(ts) {
+  if (!ts || ts.length < 14) return null
   const y = ts.slice(0,4), mo = ts.slice(4,6), d = ts.slice(6,8)
   const h = ts.slice(8,10), mi = ts.slice(10,12), s = ts.slice(12,14)
   return new Date(`${y}-${mo}-${d}T${h}:${mi}:${s}`)
 }
 
-function filenameToDate(filename) {
-  if (!filename || filename.length < 8) return ''
-  const ts = filename.substring(0, 8)
+// Compact 14-char timestamp (YYYYMMDDHHMMSS) preferred from EXIF-derived
+// taken_at, falling back to a YYYYMMDDHHMMSS filename prefix. Returns ''
+// when neither is available.
+function predTs(p) {
+  if (p.taken_at) return p.taken_at.replace(/[-T:]/g, '').slice(0, 14)
+  const m = p.filename?.match(/^(\d{14})/)
+  return m ? m[1] : ''
+}
+
+function predDate(p) {
+  const ts = predTs(p)
+  if (!ts) return ''
   return `${ts.slice(0,4)}-${ts.slice(4,6)}-${ts.slice(6,8)}`
+}
+
+function predHour(p) {
+  const ts = predTs(p)
+  return ts.length >= 10 ? parseInt(ts.slice(8, 10), 10) : -1
 }
 
 function openModal(image) { selectedImage.value = image }


### PR DESCRIPTION
## Summary
- Extract EXIF DateTimeOriginal (falling back to DigitizedTime, then IFD0 DateTime) on ingest in both the Cloud Run inference job and the local backend, stored as `taken_at` on each prediction doc.
- Gallery date/hour grouping + filters now prefer `taken_at` and fall back to a `YYYYMMDDHHMMSS` filename prefix, so headers no longer render as "undefined NaN Invalid" when filenames don't start with a timestamp.
- New `infra/scripts/backfill_taken_at.py` to populate `taken_at` on existing Firestore docs from the images already in GCS (`--uid`, `--dry-run`, `--overwrite`).

## Test plan
- [ ] Run `python infra/scripts/backfill_taken_at.py --dry-run` and confirm EXIF dates are extracted for the affected users
- [ ] Run without `--dry-run` to write `taken_at` onto existing docs
- [ ] Load the gallery and confirm date/hour headers render correctly for images that previously showed "undefined NaN Invalid"
- [ ] Kick off a fresh inference job and confirm new prediction docs carry a populated `taken_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)