### PR TITLE
Pre-warm inference: fire run_job at upload-prepare time

### DIFF
--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,9 +1,15 @@
 # ── Stage 1: build Vue frontend ───────────────────────────────────────────────
-FROM node:20-alpine AS frontend-build
+# node:20-slim (glibc/Debian) instead of alpine to sidestep the npm optional-deps
+# bug (npm/cli#4828): when package-lock.json is generated on Windows, the
+# linux-musl rollup binary isn't listed, so `npm ci` on alpine fails to find
+# @rollup/rollup-linux-x64-musl at build time. Using `npm install` (not `npm ci`)
+# also tolerates the same mismatch by resolving platform-specific optional deps
+# at install time. This stage is discarded; only dist/ is copied forward.
+FROM node:20-slim AS frontend-build
 
 WORKDIR /build
 COPY webapp/frontend/package*.json ./
-RUN npm ci --no-audit --no-fund
+RUN npm install --no-audit --no-fund
 COPY webapp/frontend/ ./
 RUN npm run build          # outputs to /build/dist
 

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import tempfile
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -22,6 +23,13 @@ from PIL import Image
 CROP_CONF_THRESHOLD = 0.2
 CROP_MAX_DIM        = 512
 CROP_JPEG_QUALITY   = 85
+
+# The web backend fires run_job at upload-prepare time, so the container
+# often starts cold-starting BEFORE the browser has finished PUT-ing all
+# files to GCS. Poll for missing blobs here, up to a generous timeout, so
+# the cold-start overlaps with (instead of following) the upload phase.
+UPLOAD_WAIT_TIMEOUT_S = 900   # 15 min — well above any realistic upload
+UPLOAD_WAIT_POLL_S    = 3
 
 _EXIF_EXIF_IFD           = 0x8769
 _EXIF_DATETIME_ORIGINAL  = 0x9003
@@ -127,6 +135,12 @@ def main():
     admin1_region = params.get("admin1_region")
     latitude      = params.get("latitude")
     longitude     = params.get("longitude")
+
+    # ── Wait for any uploads that are still in flight ─────────────────────
+    # The backend may have kicked off run_job before the browser finished
+    # PUT-ing files. Block here until all blobs exist, or fail after a
+    # generous timeout.
+    _wait_for_uploads(bucket, files, set_status)
 
     set_status("running", f"Downloading {len(files)} image(s) from storage…")
 
@@ -333,6 +347,36 @@ def main():
         set_status("done", f"Done — {count} prediction(s) saved",
                    {"completed_at": now, "summary": summary})
         print(f"[done] Saved {count} predictions for user {uid}")
+
+
+def _wait_for_uploads(bucket, files: list[str], set_status) -> None:
+    """Poll GCS until every path in `files` has an object, or time out.
+
+    First pass: if everything's already uploaded we don't touch the job
+    doc at all, so fully-uploaded-then-process flows behave identically
+    to before. Only prints a "Waiting for uploads…" status when we
+    actually need to wait.
+    """
+    missing = [p for p in files if not bucket.blob(p).exists()]
+    if not missing:
+        return
+
+    start = time.time()
+    while missing:
+        present = len(files) - len(missing)
+        set_status(
+            "running",
+            f"Waiting for uploads ({present}/{len(files)} ready)…",
+        )
+        if time.time() - start > UPLOAD_WAIT_TIMEOUT_S:
+            set_status(
+                "error",
+                f"Timed out waiting for uploads — {len(missing)}/{len(files)} "
+                f"file(s) never arrived in GCS",
+            )
+            raise SystemExit(1)
+        time.sleep(UPLOAD_WAIT_POLL_S)
+        missing = [p for p in files if not bucket.blob(p).exists()]
 
 
 def _now() -> str:

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -222,6 +222,12 @@ def main():
         now = _now()
         folder = job_doc.get("folder", "")
 
+        # Summary data shown in the upload dialog when the job completes.
+        # Category names mirror the gallery badges (animal/human/vehicle/blank).
+        by_species:  dict[str, int] = {}
+        by_category: dict[str, int] = {}
+        summary_images: list[dict] = []
+
         for pred in output.get("predictions", []):
             local_fp = pred["filepath"]
             gcs_path = path_map.get(local_fp, local_fp)
@@ -293,6 +299,22 @@ def main():
             batch_count += 1
             count += 1
 
+            # ── Accumulate summary data ───────────────────────────────
+            common = prediction_label["common_name"] if prediction_label else None
+            if common:
+                low = common.lower()
+                category = low if low in {"blank", "human", "vehicle"} else "animal"
+                by_species[common] = by_species.get(common, 0) + 1
+                by_category[category] = by_category.get(category, 0) + 1
+            else:
+                category = None
+            summary_images.append({
+                "filename":    filename,
+                "common_name": common,
+                "score":       round(pred.get("prediction_score") or 0, 3),
+                "category":    category,
+            })
+
             if batch_count >= 400:   # Firestore batch limit is 500
                 batch.commit()
                 batch = db.batch()
@@ -301,8 +323,15 @@ def main():
         if batch_count > 0:
             batch.commit()
 
+        summary = {
+            "total":        count,
+            "by_species":   by_species,
+            "by_category":  by_category,
+            "images":       summary_images,
+        }
+
         set_status("done", f"Done — {count} prediction(s) saved",
-                   {"completed_at": now})
+                   {"completed_at": now, "summary": summary})
         print(f"[done] Saved {count} predictions for user {uid}")
 
 

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -115,6 +115,10 @@ def main():
         job_ref.update(update)
         print(f"[{status}] {message}")
 
+    # First thing: confirm the container is alive so the UI stops showing
+    # the cold-start placeholder set by the web backend.
+    set_status("running", "Container started — reading job config…")
+
     # ── Read job document ─────────────────────────────────────────────────────
     job_doc = job_ref.get().to_dict()
     files   = job_doc["files"]           # list of GCS object paths

--- a/webapp/backend/main_cloud.py
+++ b/webapp/backend/main_cloud.py
@@ -265,7 +265,8 @@ async def start_process(
         "completed_at": None,
     }
 
-    _db.collection("users").document(uid).collection("jobs").document(job_id).set(job_doc)
+    job_ref = _db.collection("users").document(uid).collection("jobs").document(job_id)
+    job_ref.set(job_doc)
 
     # Trigger Cloud Run Job
     jobs_client = run_v2.JobsClient()
@@ -284,6 +285,15 @@ async def start_process(
             ),
         )
     )
+
+    # Move the job off "pending / Queued" right away so the polling UI sees a
+    # new message instead of sitting silent during container cold-start. The
+    # inference container will overwrite this as soon as main() starts.
+    job_ref.update({
+        "status":  "running",
+        "message": "Starting inference container (cold start can take up to a minute)…",
+        "updated_at": _now(),
+    })
 
     return {"job_id": job_id, "skipped": skipped}
 

--- a/webapp/backend/main_cloud.py
+++ b/webapp/backend/main_cloud.py
@@ -174,11 +174,15 @@ async def get_image(
     return RedirectResponse(url, status_code=307)
 
 
-# ── Upload ────────────────────────────────────────────────────────────────────
+# ── Upload + inference kickoff ────────────────────────────────────────────────
 
 class UploadPrepareRequest(BaseModel):
     folder: str
     filenames: list[str]
+    country: Optional[str] = None
+    admin1_region: Optional[str] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
 
 
 @app.post("/api/upload/prepare")
@@ -186,15 +190,27 @@ async def prepare_upload(
     req: UploadPrepareRequest,
     uid: str = Depends(verify_token),
 ):
-    """Return a signed PUT URL for each filename so the browser can upload directly to GCS."""
+    """Single-shot kickoff for uploads.
+
+    This used to just return signed PUT URLs; the client then separately
+    called /api/process once uploads finished. That put the Cloud Run Job
+    cold-start (30–60s) entirely after the upload phase, where the user
+    could see it.
+
+    Now we do everything here: dedupe against existing predictions, create
+    the job doc, fire run_job, and return the signed URLs alongside the
+    job_id. The container cold-starts while the browser is still uploading,
+    and the inference job.py waits for any missing files in GCS (up to a
+    generous timeout) before proceeding — so the 30–60s cold-start overlaps
+    with the upload time instead of following it.
+    """
     if not req.filenames:
         raise HTTPException(status_code=400, detail="No filenames provided")
 
     folder = _safe_folder(req.folder)
     uploads = []
-
     for raw_name in req.filenames:
-        filename  = Path(raw_name).name  # strip any path component
+        filename = Path(raw_name).name  # strip any path component
         if Path(filename).suffix.lower() not in IMAGE_EXTS:
             continue
         gcs_path = f"images/{uid}/{folder}/{filename}"
@@ -207,49 +223,40 @@ async def prepare_upload(
         )
         uploads.append({"filename": filename, "gcs_path": gcs_path, "url": url})
 
-    return {"uploads": uploads, "folder": folder}
-
-
-# ── Processing jobs ───────────────────────────────────────────────────────────
-
-class ProcessRequest(BaseModel):
-    folder: str
-    gcs_paths: list[str]              # already-uploaded GCS object paths
-    country: Optional[str] = None
-    admin1_region: Optional[str] = None
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
-
-
-@app.post("/api/process", status_code=202)
-async def start_process(
-    req: ProcessRequest,
-    uid: str = Depends(verify_token),
-):
-    if not req.gcs_paths:
-        raise HTTPException(status_code=400, detail="No files to process")
-
-    # Deduplicate — skip GCS paths that already have a prediction doc
-    existing = _existing_gcs_paths(uid)
-    new_paths = [p for p in req.gcs_paths if p not in existing]
-    skipped   = len(req.gcs_paths) - len(new_paths)
-
-    if not new_paths:
+    if not uploads:
         return {
-            "job_id": None,
-            "message": f"All {len(req.gcs_paths)} image(s) already processed — nothing to do",
-            "skipped": skipped,
+            "uploads": [], "folder": folder,
+            "job_id": None, "skipped": 0,
+            "message": "No supported image files found",
         }
 
+    # Dedupe — skip GCS paths that already have a prediction doc
+    existing   = _existing_gcs_paths(uid)
+    new_paths  = [u["gcs_path"] for u in uploads if u["gcs_path"] not in existing]
+    skipped    = len(uploads) - len(new_paths)
+    new_upload_set = set(new_paths)
+
+    # Still need to return signed URLs for new files only — the browser
+    # shouldn't bother re-uploading files we'll skip anyway.
+    uploads = [u for u in uploads if u["gcs_path"] in new_upload_set]
+
+    if not uploads:
+        return {
+            "uploads": [], "folder": folder,
+            "job_id": None, "skipped": skipped,
+            "message": f"All {skipped} image(s) already processed — nothing to do",
+        }
+
+    # ── Create job doc and fire run_job NOW, in parallel with uploads ────
     job_id = uuid.uuid4().hex[:8]
     now    = _now()
-
     job_doc = {
         "job_id":  job_id,
         "uid":     uid,
-        "folder":  req.folder,
+        "folder":  folder,
         "status":  "pending",
-        "message": f"Queued — {len(new_paths)} new image(s)" + (f", {skipped} skipped" if skipped else ""),
+        "message": f"Queued — {len(new_paths)} new image(s)"
+                   + (f", {skipped} skipped" if skipped else ""),
         "progress": {},
         "log":     [],
         "files":   new_paths,
@@ -264,11 +271,9 @@ async def start_process(
         "updated_at":   now,
         "completed_at": None,
     }
-
     job_ref = _db.collection("users").document(uid).collection("jobs").document(job_id)
     job_ref.set(job_doc)
 
-    # Trigger Cloud Run Job
     jobs_client = run_v2.JobsClient()
     jobs_client.run_job(
         run_v2.RunJobRequest(
@@ -295,7 +300,12 @@ async def start_process(
         "updated_at": _now(),
     })
 
-    return {"job_id": job_id, "skipped": skipped}
+    return {
+        "uploads":  uploads,
+        "folder":   folder,
+        "job_id":   job_id,
+        "skipped":  skipped,
+    }
 
 
 @app.get("/api/jobs/{job_id}")

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -58,6 +58,7 @@
           >
             <img
               ref="imgRef"
+              v-show="imageLoaded"
               :src="imageUrl(image.filepath)"
               :alt="image.filename"
               class="modal__img"

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -64,23 +64,31 @@
               draggable="false"
               @load="onImageLoad"
             />
-            <!-- Bbox overlays — rendered after image loads -->
-            <template v-if="imageLoaded && showBoxes">
-              <div
-                v-for="(det, i) in significantDetections"
-                :key="i"
-                class="modal__bbox"
-                :style="bboxStyle(det)"
-                :title="`${detectionLabel(det)} ${(det.conf * 100).toFixed(0)}%`"
+          </div>
+
+          <!-- Bbox overlay: lives OUTSIDE the scaled container so borders
+               and labels render at true screen pixels at any zoom level.
+               Each bbox's position is computed in screen-space from the
+               current zoom/pan/baseSize, so the boxes still track the
+               image exactly as it's panned or zoomed. -->
+          <div
+            v-if="imageLoaded && showBoxes && baseSize.w"
+            class="modal__bbox-overlay"
+          >
+            <div
+              v-for="(det, i) in significantDetections"
+              :key="i"
+              class="modal__bbox"
+              :style="bboxScreenStyle(det)"
+              :title="`${detectionLabel(det)} ${(det.conf * 100).toFixed(0)}%`"
+            >
+              <span
+                class="modal__bbox-label"
+                :style="{ background: categoryColor(det.category) }"
               >
-                <span
-                  class="modal__bbox-label"
-                  :style="{ background: categoryColor(det.category), transform: `scale(${1 / zoom})` }"
-                >
-                  {{ detectionLabel(det) }} {{ (det.conf * 100).toFixed(0) }}%
-                </span>
-              </div>
-            </template>
+                {{ detectionLabel(det) }} {{ (det.conf * 100).toFixed(0) }}%
+              </span>
+            </div>
           </div>
 
           <!-- Navigation arrows -->
@@ -341,16 +349,29 @@ function detectionLabel(det) {
   return capitalize(det.label)
 }
 
-function bboxStyle(det) {
+/**
+ * Compute a bbox's rect in wrap-local screen pixels for the overlay.
+ *
+ * The overlay is a sibling of the scaled container (not a child), so it
+ * doesn't participate in the CSS transform. Re-deriving `left/top/w/h`
+ * from (zoom, panX, panY, baseSize) here lets the bbox track the image
+ * exactly while its border and label render at native pixel size — no
+ * counter-scaling, no bitmap-scale blur on composite layers.
+ */
+function bboxScreenStyle(det) {
+  const wrap = wrapRef.value
+  const { w: bw, h: bh } = baseSize.value
+  if (!wrap || !bw || !bh) return null
   const [x, y, w, h] = det.bbox
+  const baseX = (wrap.clientWidth  - bw) / 2
+  const baseY = (wrap.clientHeight - bh) / 2
+  const z     = zoom.value
   return {
-    left:   `${x * 100}%`,
-    top:    `${y * 100}%`,
-    width:  `${w * 100}%`,
-    height: `${h * 100}%`,
+    left:        `${baseX + panX.value + x * bw * z}px`,
+    top:         `${baseY + panY.value + y * bh * z}px`,
+    width:       `${w * bw * z}px`,
+    height:      `${h * bh * z}px`,
     borderColor: categoryColor(det.category),
-    // Counter-scale the border so it stays visually crisp at any zoom level.
-    borderWidth: `${2 / zoom.value}px`,
   }
 }
 
@@ -791,6 +812,16 @@ watch(() => props.image, () => {
   user-select: none;
 }
 
+/* Screen-space overlay for bounding boxes.
+   Lives outside the scaled .modal__canvas-container so borders and
+   labels always render at native pixel size, no matter how far we've
+   zoomed in. wrap has overflow:hidden so off-screen boxes clip cleanly. */
+.modal__bbox-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
 .modal__bbox {
   position: absolute;
   border: 2px solid;
@@ -798,14 +829,9 @@ watch(() => props.image, () => {
 }
 
 .modal__bbox-label {
-  /* Anchor the label just above the bbox's top-left. The inline
-     transform: scale(1/zoom) keeps the label visually the same size at
-     any zoom level; transform-origin pins the bottom-left corner (which
-     sits on the bbox's top edge) so the label stays attached. */
   position: absolute;
   bottom: 100%;
-  left: 0;
-  transform-origin: 0 100%;
+  left: -2px;
   font-size: 11px;
   font-weight: 600;
   color: #000;

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -102,6 +102,12 @@
             :det="det"
             :color="categoryColor(det.category)"
             :label="detectionLabel(det)"
+            :class="{ 'crop--active': zoomedDetIndex === i }"
+            role="button"
+            tabindex="0"
+            @click="onCropClick(i, det)"
+            @keydown.enter.prevent="onCropClick(i, det)"
+            @keydown.space.prevent="onCropClick(i, det)"
           />
         </div>
         </div><!-- end .modal__left -->
@@ -243,11 +249,14 @@ const zoom = ref(1)
 const panX = ref(0)
 const panY = ref(0)
 const isPanning = ref(false)
+const zoomedDetIndex = ref(null)   // which crop (if any) the auto-zoom is centred on
 let resizeObserver = null
 let dragStart = null
 
 const MAX_ZOOM = 8
 const MIN_ZOOM = 1
+const AUTO_MAX_ZOOM = 20           // crop-click can push past MAX_ZOOM for tiny detections
+const CROP_FILL_FRACTION = 0.7     // target: bbox covers ~70% of the view's matching dim
 
 const containerStyle = computed(() => {
   const { w, h } = baseSize.value
@@ -373,7 +382,47 @@ function resetZoom() {
   panX.value = 0
   panY.value = 0
   isPanning.value = false
+  zoomedDetIndex.value = null
   dragStart = null
+}
+
+/**
+ * Auto-zoom the viewport so that `det.bbox` fills ~CROP_FILL_FRACTION of
+ * whichever view dimension the bbox is longer in, then centre the bbox.
+ */
+function zoomToDetection(det) {
+  const wrap = wrapRef.value
+  const { w: baseW, h: baseH } = baseSize.value
+  if (!wrap || !baseW || !baseH || !det?.bbox) return
+  const [bx, by, bw, bh] = det.bbox
+  const bboxPxW = bw * baseW
+  const bboxPxH = bh * baseH
+  if (bboxPxW <= 0 || bboxPxH <= 0) return
+  const wrapW = wrap.clientWidth
+  const wrapH = wrap.clientHeight
+  // Whichever constraint saturates first = bbox fills 70% of that view dim.
+  const zoomA = (CROP_FILL_FRACTION * wrapW) / bboxPxW
+  const zoomB = (CROP_FILL_FRACTION * wrapH) / bboxPxH
+  const newZoom = Math.max(MIN_ZOOM, Math.min(AUTO_MAX_ZOOM, Math.min(zoomA, zoomB)))
+  const baseX = (wrapW - baseW) / 2
+  const baseY = (wrapH - baseH) / 2
+  const centerX = (bx + bw / 2) * baseW
+  const centerY = (by + bh / 2) * baseH
+  panX.value = wrapW / 2 - baseX - centerX * newZoom
+  panY.value = wrapH / 2 - baseY - centerY * newZoom
+  zoom.value = newZoom
+  clampPan()
+}
+
+function onCropClick(i, det) {
+  // Toggle: clicking the currently-auto-zoomed crop resets; clicking any
+  // other crop jumps to it.
+  if (zoomedDetIndex.value === i && zoom.value > 1) {
+    resetZoom()
+    return
+  }
+  zoomToDetection(det)
+  zoomedDetIndex.value = i
 }
 
 function clampPan() {
@@ -406,7 +455,10 @@ function onWheel(e) {
   const baseX = (wrap.clientWidth  - baseSize.value.w) / 2
   const baseY = (wrap.clientHeight - baseSize.value.h) / 2
   const factor = Math.exp(-e.deltaY * 0.0015)
-  const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom.value * factor))
+  // Raise the wheel cap to the current zoom so a crop-click auto-zoom
+  // (which may exceed MAX_ZOOM) isn't snapped back on the next scroll.
+  const maxZoom = Math.max(MAX_ZOOM, zoom.value)
+  const newZoom = Math.max(MIN_ZOOM, Math.min(maxZoom, zoom.value * factor))
   if (newZoom === zoom.value) return
   // Preserve the container-local point under the cursor.
   const cx = (mouseX - baseX - panX.value) / zoom.value
@@ -414,6 +466,7 @@ function onWheel(e) {
   panX.value = mouseX - baseX - cx * newZoom
   panY.value = mouseY - baseY - cy * newZoom
   zoom.value = newZoom
+  zoomedDetIndex.value = null
   clampPan()
 }
 
@@ -435,6 +488,7 @@ function onDoubleClick(e) {
   panX.value = mouseX - baseX - cx * newZoom
   panY.value = mouseY - baseY - cy * newZoom
   zoom.value = newZoom
+  zoomedDetIndex.value = null
   clampPan()
 }
 
@@ -451,6 +505,9 @@ function onMouseMove(e) {
   if (!dragStart) return
   panX.value = e.clientX - dragStart.x
   panY.value = e.clientY - dragStart.y
+  // User panned manually — a follow-up click on any crop should re-zoom
+  // rather than reset.
+  zoomedDetIndex.value = null
   clampPan()
 }
 
@@ -692,6 +749,17 @@ watch(() => props.image, () => {
   flex-shrink: 0;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
+}
+
+.modal__carousel > .crop {
+  cursor: pointer;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+.modal__carousel > .crop:hover {
+  transform: translateY(-1px);
+}
+.modal__carousel > .crop--active {
+  box-shadow: 0 0 0 2px var(--accent, #60a5fa);
 }
 
 .modal__image-wrap {

--- a/webapp/frontend/src/components/ImageModal.vue
+++ b/webapp/frontend/src/components/ImageModal.vue
@@ -43,17 +43,25 @@
       <div class="modal__body">
         <div class="modal__left">
         <!-- Image + bbox overlay -->
-        <div class="modal__image-wrap" ref="wrapRef">
+        <div
+          class="modal__image-wrap"
+          ref="wrapRef"
+          @wheel.prevent="onWheel"
+        >
           <div
             class="modal__canvas-container"
             ref="containerRef"
+            :class="{ 'modal__canvas-container--zoomed': zoom > 1, 'modal__canvas-container--panning': isPanning }"
             :style="containerStyle"
+            @mousedown="onMouseDown"
+            @dblclick="onDoubleClick"
           >
             <img
               ref="imgRef"
               :src="imageUrl(image.filepath)"
               :alt="image.filename"
               class="modal__img"
+              draggable="false"
               @load="onImageLoad"
             />
             <!-- Bbox overlays — rendered after image loads -->
@@ -65,7 +73,10 @@
                 :style="bboxStyle(det)"
                 :title="`${detectionLabel(det)} ${(det.conf * 100).toFixed(0)}%`"
               >
-                <span class="modal__bbox-label" :style="{ background: categoryColor(det.category) }">
+                <span
+                  class="modal__bbox-label"
+                  :style="{ background: categoryColor(det.category), transform: `scale(${1 / zoom})` }"
+                >
                   {{ detectionLabel(det) }} {{ (det.conf * 100).toFixed(0) }}%
                 </span>
               </div>
@@ -76,6 +87,10 @@
           <button class="modal__nav modal__nav--prev" @click="navigate(-1)" :disabled="currentIndex <= 0">‹</button>
           <button class="modal__nav modal__nav--next" @click="navigate(1)" :disabled="currentIndex >= allImages.length - 1">›</button>
           <div class="modal__position">{{ currentIndex + 1 }} / {{ allImages.length }}</div>
+          <div v-if="zoom > 1" class="modal__zoom-indicator">
+            {{ Math.round(zoom * 100) }}%
+            <button class="modal__zoom-reset" title="Reset zoom" @click="resetZoom">✕</button>
+          </div>
         </div>
 
         <!-- Detection crop carousel -->
@@ -223,8 +238,27 @@ const imgRef = ref(null)
 const containerRef = ref(null)
 const wrapRef = ref(null)
 const imageLoaded = ref(false)
-const containerStyle = ref(null)
+const baseSize = ref({ w: 0, h: 0 })
+const zoom = ref(1)
+const panX = ref(0)
+const panY = ref(0)
+const isPanning = ref(false)
 let resizeObserver = null
+let dragStart = null
+
+const MAX_ZOOM = 8
+const MIN_ZOOM = 1
+
+const containerStyle = computed(() => {
+  const { w, h } = baseSize.value
+  if (!w || !h) return null
+  return {
+    width:           `${w}px`,
+    height:          `${h}px`,
+    transform:       `translate(${panX.value}px, ${panY.value}px) scale(${zoom.value})`,
+    transformOrigin: '0 0',
+  }
+})
 
 const currentIndex = computed(() => props.allImages.indexOf(props.image))
 
@@ -306,6 +340,8 @@ function bboxStyle(det) {
     width:  `${w * 100}%`,
     height: `${h * 100}%`,
     borderColor: categoryColor(det.category),
+    // Counter-scale the border so it stays visually crisp at any zoom level.
+    borderWidth: `${2 / zoom.value}px`,
   }
 }
 
@@ -322,12 +358,107 @@ function computeContainerSize() {
     h = maxH
     w = h * ar
   }
-  containerStyle.value = { width: `${w}px`, height: `${h}px` }
+  baseSize.value = { w, h }
+  clampPan()
 }
 
 function onImageLoad() {
   imageLoaded.value = true
   computeContainerSize()
+}
+
+// ── Zoom + pan ────────────────────────────────────────────────────────────────
+function resetZoom() {
+  zoom.value = 1
+  panX.value = 0
+  panY.value = 0
+  isPanning.value = false
+  dragStart = null
+}
+
+function clampPan() {
+  const wrap = wrapRef.value
+  if (!wrap) return
+  const { w, h } = baseSize.value
+  const s = zoom.value
+  const scaledW = w * s
+  const scaledH = h * s
+  // Layout position of the unscaled container inside wrap (flex-centered):
+  const baseX = (wrap.clientWidth  - w) / 2
+  const baseY = (wrap.clientHeight - h) / 2
+  // Image should always cover (or be centered within) wrap.
+  const minX = scaledW > wrap.clientWidth  ? wrap.clientWidth  - scaledW - baseX : -baseX
+  const maxX = scaledW > wrap.clientWidth  ? -baseX                              : -baseX
+  const minY = scaledH > wrap.clientHeight ? wrap.clientHeight - scaledH - baseY : -baseY
+  const maxY = scaledH > wrap.clientHeight ? -baseY                              : -baseY
+  if (scaledW <= wrap.clientWidth)  panX.value = 0
+  else panX.value = Math.min(maxX, Math.max(minX, panX.value))
+  if (scaledH <= wrap.clientHeight) panY.value = 0
+  else panY.value = Math.min(maxY, Math.max(minY, panY.value))
+}
+
+function onWheel(e) {
+  const wrap = wrapRef.value
+  if (!wrap || !baseSize.value.w) return
+  const rect = wrap.getBoundingClientRect()
+  const mouseX = e.clientX - rect.left
+  const mouseY = e.clientY - rect.top
+  const baseX = (wrap.clientWidth  - baseSize.value.w) / 2
+  const baseY = (wrap.clientHeight - baseSize.value.h) / 2
+  const factor = Math.exp(-e.deltaY * 0.0015)
+  const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom.value * factor))
+  if (newZoom === zoom.value) return
+  // Preserve the container-local point under the cursor.
+  const cx = (mouseX - baseX - panX.value) / zoom.value
+  const cy = (mouseY - baseY - panY.value) / zoom.value
+  panX.value = mouseX - baseX - cx * newZoom
+  panY.value = mouseY - baseY - cy * newZoom
+  zoom.value = newZoom
+  clampPan()
+}
+
+function onDoubleClick(e) {
+  const wrap = wrapRef.value
+  if (!wrap || !baseSize.value.w) return
+  if (zoom.value > 1) {
+    resetZoom()
+    return
+  }
+  const rect = wrap.getBoundingClientRect()
+  const mouseX = e.clientX - rect.left
+  const mouseY = e.clientY - rect.top
+  const baseX = (wrap.clientWidth  - baseSize.value.w) / 2
+  const baseY = (wrap.clientHeight - baseSize.value.h) / 2
+  const newZoom = 2.5
+  const cx = mouseX - baseX
+  const cy = mouseY - baseY
+  panX.value = mouseX - baseX - cx * newZoom
+  panY.value = mouseY - baseY - cy * newZoom
+  zoom.value = newZoom
+  clampPan()
+}
+
+function onMouseDown(e) {
+  if (zoom.value <= 1 || e.button !== 0) return
+  dragStart = { x: e.clientX - panX.value, y: e.clientY - panY.value }
+  isPanning.value = true
+  window.addEventListener('mousemove', onMouseMove)
+  window.addEventListener('mouseup', onMouseUp)
+  e.preventDefault()
+}
+
+function onMouseMove(e) {
+  if (!dragStart) return
+  panX.value = e.clientX - dragStart.x
+  panY.value = e.clientY - dragStart.y
+  clampPan()
+}
+
+function onMouseUp() {
+  dragStart = null
+  isPanning.value = false
+  window.removeEventListener('mousemove', onMouseMove)
+  window.removeEventListener('mouseup', onMouseUp)
 }
 
 function navigate(delta) {
@@ -358,12 +489,15 @@ onMounted(() => {
 })
 onUnmounted(() => {
   window.removeEventListener('keydown', onKeydown)
+  window.removeEventListener('mousemove', onMouseMove)
+  window.removeEventListener('mouseup', onMouseUp)
   resizeObserver?.disconnect()
 })
 
 watch(() => props.image, () => {
   imageLoaded.value = false
-  containerStyle.value = null
+  baseSize.value = { w: 0, h: 0 }
+  resetZoom()
   confirmingDelete.value = false
   deleteError.value = ''
   loadExif()
@@ -573,12 +707,20 @@ watch(() => props.image, () => {
 .modal__canvas-container {
   position: relative;
   display: block;
+  will-change: transform;
 }
+
+.modal__canvas-container--zoomed { cursor: grab; }
+.modal__canvas-container--zoomed.modal__canvas-container--panning { cursor: grabbing; }
+.modal__canvas-container--panning,
+.modal__canvas-container--panning * { user-select: none; }
 
 .modal__img {
   display: block;
   width: 100%;
   height: 100%;
+  -webkit-user-drag: none;
+  user-select: none;
 }
 
 .modal__bbox {
@@ -588,9 +730,14 @@ watch(() => props.image, () => {
 }
 
 .modal__bbox-label {
+  /* Anchor the label just above the bbox's top-left. The inline
+     transform: scale(1/zoom) keeps the label visually the same size at
+     any zoom level; transform-origin pins the bottom-left corner (which
+     sits on the bbox's top edge) so the label stays attached. */
   position: absolute;
-  top: -22px;
-  left: -1px;
+  bottom: 100%;
+  left: 0;
+  transform-origin: 0 100%;
   font-size: 11px;
   font-weight: 600;
   color: #000;
@@ -633,6 +780,38 @@ watch(() => props.image, () => {
   padding: 2px 8px;
   border-radius: 999px;
 }
+
+.modal__zoom-indicator {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px 2px 8px;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+}
+
+.modal__zoom-reset {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 11px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  opacity: 0.7;
+}
+.modal__zoom-reset:hover { opacity: 1; background: rgba(255,255,255,0.15); }
 
 /* Side panel */
 .modal__panel {

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -178,10 +178,10 @@
           </ul>
         </section>
 
-        <!-- Log: always visible while running or on error; collapsed by
-             default on success so the summary takes precedence. -->
+        <!-- Raw log — hidden by default; revealed via the "more details…"
+             toggle at the bottom of the dialog. -->
         <pre
-          v-if="job.log?.length && (job.status !== 'done' || !job.summary || showLog)"
+          v-if="showLog && job.log?.length"
           ref="logEl"
           class="progress__log"
         >{{ job.log.join('\n') }}</pre>
@@ -193,13 +193,17 @@
           <button v-if="job.status === 'error' || job.status === 'done'" class="btn" @click="reset">
             Process another folder
           </button>
-          <button
-            v-if="job.log?.length"
-            class="btn summary__log-toggle"
-            type="button"
-            @click="showLog = !showLog"
-          >{{ showLog ? 'Hide log' : 'Show log' }}</button>
         </div>
+
+        <!-- Details disclosure — stays at the very bottom regardless of
+             job status so the log is never shown without the user
+             opting in. -->
+        <button
+          v-if="job.log?.length"
+          class="progress__details-toggle"
+          type="button"
+          @click="showLog = !showLog"
+        >{{ showLog ? 'Hide details' : 'More details…' }}</button>
       </div>
 
     </div>
@@ -869,7 +873,21 @@ onUnmounted(() => {
   text-align: right;
 }
 
-.summary__log-toggle {
-  margin-left: auto;
+.progress__details-toggle {
+  align-self: center;
+  margin-top: 4px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.progress__details-toggle:hover {
+  color: var(--text);
+  text-decoration: underline;
 }
 </style>

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -138,7 +138,53 @@
           <strong>Error:</strong> {{ job.message }}
         </div>
 
-        <pre v-if="job.log?.length" ref="logEl" class="progress__log">{{ job.log.join('\n') }}</pre>
+        <!-- Summary shown when the inference job completes -->
+        <section v-if="job.status === 'done' && job.summary" class="summary">
+          <header class="summary__header">
+            <span class="summary__count">
+              {{ job.summary.total }} image{{ job.summary.total === 1 ? '' : 's' }} processed
+            </span>
+            <span v-if="categoryEntries.length" class="summary__badges">
+              <span
+                v-for="[cat, n] in categoryEntries"
+                :key="cat"
+                :class="`badge badge--${cat}`"
+              >{{ cat }}: {{ n }}</span>
+            </span>
+          </header>
+
+          <div v-if="speciesEntries.length" class="summary__species">
+            <span
+              v-for="[name, n] in speciesEntries"
+              :key="name"
+              class="summary__species-chip"
+            >{{ capitalize(name) }} × {{ n }}</span>
+          </div>
+
+          <ul v-if="job.summary.images?.length" class="summary__list">
+            <li
+              v-for="(img, i) in job.summary.images"
+              :key="i"
+              class="summary__row"
+            >
+              <span class="summary__filename" :title="img.filename">{{ img.filename }}</span>
+              <span
+                v-if="img.category"
+                :class="`badge badge--${img.category} summary__label`"
+              >{{ img.common_name ? capitalize(img.common_name) : img.category }}</span>
+              <span v-else class="summary__label summary__label--empty">—</span>
+              <span v-if="img.score" class="summary__score">{{ Math.round(img.score * 100) }}%</span>
+            </li>
+          </ul>
+        </section>
+
+        <!-- Log: always visible while running or on error; collapsed by
+             default on success so the summary takes precedence. -->
+        <pre
+          v-if="job.log?.length && (job.status !== 'done' || !job.summary || showLog)"
+          ref="logEl"
+          class="progress__log"
+        >{{ job.log.join('\n') }}</pre>
 
         <div class="progress__actions">
           <button v-if="job.status === 'done'" class="btn btn--primary" @click="$emit('done')">
@@ -147,6 +193,12 @@
           <button v-if="job.status === 'error' || job.status === 'done'" class="btn" @click="reset">
             Process another folder
           </button>
+          <button
+            v-if="job.log?.length"
+            class="btn summary__log-toggle"
+            type="button"
+            @click="showLog = !showLog"
+          >{{ showLog ? 'Hide log' : 'Show log' }}</button>
         </div>
       </div>
 
@@ -204,6 +256,22 @@ const canClose = computed(() =>
 )
 
 const progressEntries = computed(() => Object.entries(job.value.progress ?? {}))
+
+// Summary tallies, sorted by count desc.
+const categoryEntries = computed(() =>
+  Object.entries(job.value.summary?.by_category ?? {}).sort((a, b) => b[1] - a[1])
+)
+const speciesEntries = computed(() =>
+  Object.entries(job.value.summary?.by_species ?? {}).sort((a, b) => b[1] - a[1])
+)
+
+// Expand/collapse the raw log after success. Log stays visible by default
+// while running or on error.
+const showLog = ref(false)
+
+function capitalize(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s
+}
 
 // Show the cold-start/warm-up hint until SpeciesNet starts reporting tqdm
 // progress (or the job finishes). The hint is the key signal that the app
@@ -407,6 +475,7 @@ function reset() {
   stopElapsed()
   elapsedSec.value      = null
   processingStart.value = null
+  showLog.value         = false
 }
 
 // Auto-scroll log
@@ -704,5 +773,103 @@ onUnmounted(() => {
   scrollbar-width: thin;
 }
 
-.progress__actions { display: flex; gap: 8px; }
+.progress__actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* Summary panel */
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.summary__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.summary__count {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.summary__badges {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-left: auto;
+}
+
+.summary__species {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.summary__species-chip {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.summary__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.summary__row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.summary__row:last-child { border-bottom: none; }
+
+.summary__filename {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.summary__label {
+  font-size: 11px;
+}
+
+.summary__label--empty {
+  color: var(--text-muted);
+}
+
+.summary__score {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 32px;
+  text-align: right;
+}
+
+.summary__log-toggle {
+  margin-left: auto;
+}
 </style>

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -80,8 +80,12 @@
         </div>
 
         <div v-if="submitError" class="modal__error">{{ submitError }}</div>
-        <button type="submit" class="btn btn--primary" :disabled="AUTH_ENABLED && files.length === 0">
-          {{ AUTH_ENABLED ? 'Upload &amp; Process' : 'Run SpeciesNet' }}
+        <button
+          type="submit"
+          class="btn btn--primary"
+          :disabled="submitting || (AUTH_ENABLED && files.length === 0)"
+        >
+          {{ submitting ? 'Starting…' : (AUTH_ENABLED ? 'Upload &amp; Process' : 'Run SpeciesNet') }}
         </button>
       </form>
 
@@ -238,6 +242,11 @@ const locationError = ref('')
 const latitude     = ref(null)
 const longitude    = ref(null)
 const submitError  = ref('')
+// True while submit() is in flight. Without this, a double-click (or pressing
+// Enter twice quickly) re-enters submit() before the prepare request returns,
+// which mints a second job and uploads everything again — visible as the
+// upload counter ticking past uploadTotal.
+const submitting   = ref(false)
 
 // Phase: 'form' | 'uploading' | 'processing'
 const phase = ref('form')
@@ -358,6 +367,8 @@ function useCurrentLocation() {
 // ── Submit ────────────────────────────────────────────────────────────────────
 
 async function submit() {
+  if (submitting.value) return
+  submitting.value = true
   submitError.value = ''
   try {
     if (AUTH_ENABLED) {
@@ -367,6 +378,8 @@ async function submit() {
     }
   } catch (e) {
     submitError.value = e.message
+  } finally {
+    submitting.value = false
   }
 }
 
@@ -419,9 +432,16 @@ async function submitCloud() {
 
   // Upload files to GCS. The inference container is already polling for
   // them and will proceed as soon as the last one lands.
-  for (const { filename, url } of uploads) {
+  //
+  // Worker pool: N workers pull from a shared cursor. 6 matches the
+  // browser's per-origin HTTP/1.1 connection cap; GCS supports HTTP/2 so
+  // in practice these run multiplexed. Pushing higher gives diminishing
+  // returns and risks throttling on slow uplinks.
+  const CONCURRENCY = 6
+  let cursor = 0
+  const uploadOne = async ({ filename, url }) => {
     const file = files.value.find(f => f.name === filename)
-    if (!file) continue
+    if (!file) return
     const putRes = await fetch(url, {
       method: 'PUT',
       headers: { 'Content-Type': 'image/jpeg' },
@@ -430,6 +450,16 @@ async function submitCloud() {
     if (!putRes.ok) throw new Error(`Failed to upload ${filename}: HTTP ${putRes.status}`)
     uploadDone.value++
   }
+  const workers = Array.from(
+    { length: Math.min(CONCURRENCY, uploads.length) },
+    async () => {
+      while (cursor < uploads.length) {
+        const i = cursor++
+        await uploadOne(uploads[i])
+      }
+    },
+  )
+  await Promise.all(workers)
 
   // All uploads done — switch to the richer processing view. The job
   // might already be running (or done!) by now.

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -101,8 +101,19 @@
         <div class="progress__status">
           <span :class="`progress__dot progress__dot--${job.status}`"></span>
           <span class="progress__message">{{ job.message }}</span>
+          <span v-if="elapsedSec !== null && job.status !== 'done'" class="progress__elapsed">
+            {{ formatElapsed(elapsedSec) }}
+          </span>
           <span v-if="job.status === 'done'" class="progress__count">✓</span>
         </div>
+
+        <!-- Cold-start / preparing hint while we're waiting for SpeciesNet
+             to start emitting progress bars -->
+        <p v-if="showWaitingHint" class="progress__hint">
+          Starting a fresh inference container and loading the SpeciesNet model.
+          This typically takes 30–60 seconds on the first upload and is much
+          faster on subsequent runs.
+        </p>
 
         <div v-if="progressEntries.length" class="progress__stages">
           <div v-for="[label, p] in progressEntries" :key="label" class="progress__stage">
@@ -179,12 +190,48 @@ const job   = ref({ status: 'running', message: 'Queued', log: [], progress: {} 
 const logEl = ref(null)
 let pollTimer = null
 
+// Elapsed-seconds clock that starts when the processing phase begins.
+// Updating a reactive ref every second is enough to render a live timer;
+// the user gets visible reassurance that the app is still working even
+// when `job.message` hasn't changed in a while (cold-start, model load).
+const elapsedSec      = ref(null)
+const processingStart = ref(null)
+let   elapsedTimer    = null
+
 const canClose = computed(() =>
   phase.value === 'form' ||
   (phase.value === 'processing' && (job.value.status === 'done' || job.value.status === 'error'))
 )
 
 const progressEntries = computed(() => Object.entries(job.value.progress ?? {}))
+
+// Show the cold-start/warm-up hint until SpeciesNet starts reporting tqdm
+// progress (or the job finishes). The hint is the key signal that the app
+// is still working during the silent model-load stretch.
+const showWaitingHint = computed(() =>
+  phase.value === 'processing'
+  && (job.value.status === 'pending' || job.value.status === 'running')
+  && progressEntries.value.length === 0,
+)
+
+function formatElapsed(s) {
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  return `${m}:${String(r).padStart(2, '0')}`
+}
+
+function startElapsed() {
+  processingStart.value = Date.now()
+  elapsedSec.value      = 0
+  if (elapsedTimer) clearInterval(elapsedTimer)
+  elapsedTimer = setInterval(() => {
+    elapsedSec.value = Math.floor((Date.now() - processingStart.value) / 1000)
+  }, 1000)
+}
+
+function stopElapsed() {
+  if (elapsedTimer) { clearInterval(elapsedTimer); elapsedTimer = null }
+}
 
 // ── File handling (cloud) ─────────────────────────────────────────────────────
 
@@ -304,6 +351,7 @@ async function submitCloud() {
 
   jobId.value = procData.job_id
   phase.value = 'processing'
+  startElapsed()
   startPolling()
 }
 
@@ -324,6 +372,7 @@ async function submitLocal() {
 
   jobId.value = data.job_id
   phase.value = 'processing'
+  startElapsed()
   startPolling()
 }
 
@@ -342,6 +391,7 @@ async function pollJob() {
     if (data.status === 'done' || data.status === 'error') {
       clearInterval(pollTimer)
       pollTimer = null
+      stopElapsed()
     }
   } catch { /* network blip — keep polling */ }
 }
@@ -354,6 +404,9 @@ function reset() {
   uploadDone.value = 0
   uploadTotal.value = 0
   submitError.value = ''
+  stopElapsed()
+  elapsedSec.value      = null
+  processingStart.value = null
 }
 
 // Auto-scroll log
@@ -362,7 +415,10 @@ watch(() => job.value.log, async () => {
   if (logEl.value) logEl.value.scrollTop = logEl.value.scrollHeight
 })
 
-onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+  stopElapsed()
+})
 </script>
 
 <style scoped>
@@ -552,6 +608,28 @@ onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.progress__elapsed {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  padding: 1px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface2);
+}
+
+.progress__hint {
+  margin: 0;
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 
 /* Stage bars */

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -85,7 +85,9 @@
         </button>
       </form>
 
-      <!-- ── Upload progress (cloud only) ── -->
+      <!-- ── Upload progress (cloud only) ──
+           The inference container is already cold-starting in parallel,
+           so surface the live job status underneath the upload bar. -->
       <div v-else-if="phase === 'uploading'" class="modal__progress">
         <div class="progress__status">
           <span class="progress__dot progress__dot--running"></span>
@@ -93,6 +95,13 @@
         </div>
         <div class="progress__stage-track" style="margin-top:4px">
           <div class="progress__stage-fill" :style="{ width: uploadPct + '%' }"></div>
+        </div>
+        <div v-if="job.message" class="progress__status" style="margin-top:10px">
+          <span :class="`progress__dot progress__dot--${job.status}`"></span>
+          <span class="progress__message">{{ job.message }}</span>
+          <span v-if="elapsedSec !== null" class="progress__elapsed">
+            {{ formatElapsed(elapsedSec) }}
+          </span>
         </div>
       </div>
 
@@ -365,25 +374,52 @@ async function submitCloud() {
   if (!files.value.length) throw new Error('Please select at least one image file.')
   if (!folder.value.trim()) throw new Error('Please enter a folder name.')
 
-  // 1. Get signed upload URLs
-  const prepRes = await apiFetch('/api/upload/prepare', {
+  // Single-shot kickoff: the backend now returns signed URLs AND fires
+  // run_job right away. The Cloud Run Job cold-starts (30–60s) overlaps
+  // with the browser upload instead of following it.
+  const body = {
+    folder:    folder.value.trim(),
+    filenames: files.value.map(f => f.name),
+  }
+  if (country.value)        body.country       = country.value.toUpperCase()
+  if (admin1Region.value)   body.admin1_region = admin1Region.value.toUpperCase()
+  if (latitude.value  != null) body.latitude    = latitude.value
+  if (longitude.value != null) body.longitude   = longitude.value
+
+  const prepRes  = await apiFetch('/api/upload/prepare', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ folder: folder.value.trim(), filenames: files.value.map(f => f.name) }),
+    body: JSON.stringify(body),
   })
   const prepData = await prepRes.json()
   if (!prepRes.ok) throw new Error(prepData.detail ?? `HTTP ${prepRes.status}`)
 
   const uploads = prepData.uploads
-  if (!uploads.length) throw new Error('No supported image files found.')
 
-  // 2. Upload files directly to GCS
-  phase.value    = 'uploading'
+  if (!prepData.job_id) {
+    // Either everything was already processed or nothing supported.
+    job.value = {
+      status: 'done',
+      message: prepData.message ?? 'Nothing to do',
+      log: [], progress: {},
+    }
+    phase.value = 'processing'
+    return
+  }
+
+  // Job is already cold-starting. Begin polling now so any "Loading AI
+  // model…" / "Waiting for uploads…" messages surface while the user
+  // watches their files upload.
+  jobId.value = prepData.job_id
+  phase.value = 'uploading'
   uploadTotal.value = uploads.length
   uploadDone.value  = 0
+  startElapsed()
+  startPolling()
 
-  const gcsPaths = []
-  for (const { filename, url, gcs_path } of uploads) {
+  // Upload files to GCS. The inference container is already polling for
+  // them and will proceed as soon as the last one lands.
+  for (const { filename, url } of uploads) {
     const file = files.value.find(f => f.name === filename)
     if (!file) continue
     const putRes = await fetch(url, {
@@ -392,39 +428,12 @@ async function submitCloud() {
       body: file,
     })
     if (!putRes.ok) throw new Error(`Failed to upload ${filename}: HTTP ${putRes.status}`)
-    gcsPaths.push(gcs_path)
     uploadDone.value++
   }
 
-  // 3. Trigger inference job
-  const body = {
-    folder:    folder.value.trim(),
-    gcs_paths: gcsPaths,
-  }
-  if (country.value)      body.country       = country.value.toUpperCase()
-  if (admin1Region.value) body.admin1_region  = admin1Region.value.toUpperCase()
-  if (latitude.value  != null) body.latitude  = latitude.value
-  if (longitude.value != null) body.longitude = longitude.value
-
-  const procRes  = await apiFetch('/api/process', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-  const procData = await procRes.json()
-  if (!procRes.ok) throw new Error(procData.detail ?? `HTTP ${procRes.status}`)
-
-  if (!procData.job_id) {
-    // Everything already processed
-    job.value = { status: 'done', message: procData.message, log: [], progress: {} }
-    phase.value = 'processing'
-    return
-  }
-
-  jobId.value = procData.job_id
+  // All uploads done — switch to the richer processing view. The job
+  // might already be running (or done!) by now.
   phase.value = 'processing'
-  startElapsed()
-  startPolling()
 }
 
 async function submitLocal() {


### PR DESCRIPTION
## Summary

The Cloud Run Job cold-start (30–60s) used to sit between the user clicking _Upload & Process_ and the first real progress signal. Move the \`run_job\` firing earlier so it overlaps with the upload phase.

**Before:**
\`click → upload files → POST /api/process → cold-start → infer\`

**After:**
\`click → POST /api/upload/prepare (returns URLs + fires run_job) → upload + cold-start in parallel → infer\`

### Backend (\`main_cloud.py\`)

- \`/api/upload/prepare\` now does dedup + creates the job doc + fires \`run_job\` on top of returning signed PUT URLs. Accepts \`country\` / \`admin1_region\` / \`latitude\` / \`longitude\` so the job has its full config from the start.
- \`/api/process\` is removed (folded into prepare).

### Inference (\`job.py\`)

- After the initial \"container alive\" status, poll GCS for missing blobs.
- If everything's already uploaded (legacy path) we don't touch the job doc — behavior identical.
- Otherwise surface \"Waiting for uploads (X/Y ready)…\" to the UI; time out after 15 minutes.

### Frontend (\`ProcessModal.vue\`)

- \`submitCloud\` collapses its two API calls into one.
- Polling starts immediately after kickoff, so the live job status (cold-start progress, then waiting-for-uploads) surfaces underneath the upload bar.

### Expected UX

Net win depends on upload time vs. cold-start time. For a typical 50–500 image batch the upload runs ~20–60s, which is roughly the full cold-start budget — so the \"Loading AI model…\" window shrinks or disappears entirely from the user's perception.

### Note on PR ordering with #10

PR #10 (\"Slim inference container\") renames \"inference container\" → \"AI model\" in user-facing strings. This PR doesn't include those renames (they live on PR #10's branch). The line ranges don't overlap, so whichever merges second should auto-merge cleanly.

## Test plan

- [x] Upload a small batch (5 images) — confirm job kicks off immediately, cold-start runs in parallel
- [x] Upload a large batch (~100 images) — confirm \"Waiting for uploads (X/Y)\" status surfaces if cold-start finishes first
- [x] Confirm \"Loading AI model\" message appears under the upload bar during the upload phase
- [x] Confirm job transitions to processing/done/error correctly
- [x] Confirm the no-op case (all files already processed) still returns gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)