### PR TITLE
Filter gallery by folder; auto-apply after upload

### DIFF
--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -55,6 +55,7 @@
       <FilterBar
         v-if="view === 'gallery'"
         :species="allSpecies"
+        :folders="allFolders"
         :filters="filters"
         :total="predictions.length"
         :filtered="filteredPredictions.length"
@@ -159,6 +160,7 @@ const signingIn    = ref(false)
 const signInError  = ref('')
 
 const filters = reactive({
+  folder: '',
   species: '',
   minConfidence: 0,
   categories: ['animal', 'human', 'vehicle', 'blank', 'unknown'],
@@ -233,6 +235,7 @@ const filteredPredictions = computed(() => {
   return predictions.value.filter(p => {
     const cat = getCategory(p)
     if (!filters.categories.includes(cat)) return false
+    if (filters.folder && p.folder !== filters.folder) return false
     if (filters.species && p.prediction?.common_name !== filters.species) return false
     if (filters.minConfidence > 0 && (p.prediction_score ?? 0) < filters.minConfidence / 100) return false
     if (filters.hour !== null) {
@@ -265,6 +268,11 @@ const groupedEvents = computed(() => {
 const allSpecies = computed(() => {
   const names = predictions.value.map(p => p.prediction?.common_name).filter(Boolean)
   return [...new Set(names)].sort()
+})
+
+const allFolders = computed(() => {
+  const folders = predictions.value.map(p => p.folder).filter(Boolean)
+  return [...new Set(folders)].sort()
 })
 
 const stats = computed(() => ({
@@ -352,9 +360,13 @@ function applyHistogramFilter({ species, hour }) {
   view.value      = 'gallery'
 }
 
-async function onProcessDone() {
+async function onProcessDone(folder) {
   showProcess.value = false
   await loadPredictions()
+  if (folder && allFolders.value.includes(folder)) {
+    filters.folder = folder
+    view.value     = 'gallery'
+  }
 }
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────────

--- a/webapp/frontend/src/components/FilterBar.vue
+++ b/webapp/frontend/src/components/FilterBar.vue
@@ -1,5 +1,13 @@
 <template>
   <aside class="filterbar">
+    <div v-if="folders.length" class="filterbar__section">
+      <label class="filterbar__label">Folder</label>
+      <select class="filterbar__select" :value="filters.folder" @change="emit('update', { folder: $event.target.value })">
+        <option value="">All folders</option>
+        <option v-for="f in folders" :key="f" :value="f">{{ f }}</option>
+      </select>
+    </div>
+
     <div class="filterbar__section">
       <label class="filterbar__label">Species</label>
       <select class="filterbar__select" :value="filters.species" @change="emit('update', { species: $event.target.value })">
@@ -74,6 +82,7 @@
 <script setup>
 const props = defineProps({
   species: Array,
+  folders: { type: Array, default: () => [] },
   filters: Object,
   total: Number,
   filtered: Number,
@@ -104,6 +113,7 @@ function toggleCategory(key) {
 
 function clearFilters() {
   emit('update', {
+    folder: '',
     species: '',
     minConfidence: 0,
     categories: CATEGORIES.map(c => c.key),

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -186,7 +186,7 @@
         >{{ job.log.join('\n') }}</pre>
 
         <div class="progress__actions">
-          <button v-if="job.status === 'done'" class="btn btn--primary" @click="$emit('done')">
+          <button v-if="job.status === 'done'" class="btn btn--primary" @click="$emit('done', AUTH_ENABLED ? folder.trim() : '')">
             Reload gallery
           </button>
           <button v-if="job.status === 'error' || job.status === 'done'" class="btn" @click="reset">


### PR DESCRIPTION
## Summary
- After clicking **Reload gallery** at the end of an upload, the app now jumps to the gallery view filtered to just the folder that was uploaded — so the user lands on exactly the photos they just added instead of the full archive.
- Adds a new **Folder** dropdown in the filter bar (rendered only when loaded predictions carry a `folder` field) so the auto-applied filter can be cleared or switched between upload sets.
- The dropdown is hidden in local-dev mode where the local backend doesn't persist `folder` on predictions, so that flow is unchanged.

## How it works
- `ProcessModal.vue` now passes the folder name with the `done` emit.
- `App.vue` adds `folder` to the reactive `filters`, an `allFolders` computed for the dropdown, the actual filter predicate, and an `onProcessDone(folder)` that auto-sets the filter (only when the folder actually appears on the freshly-loaded predictions).
- `FilterBar.vue` adds the dropdown above Species, and includes folder in `clearFilters`.

## Test plan
- [x] Vite dev server boots clean, no console errors
- [x] Folder dropdown is hidden when predictions have no `folder` (local-mode behavior preserved)
- [x] After injecting `folder` values into the predictions response, the dropdown appears with sorted options and selecting one drops the gallery count to that folder's slice (verified 233/237 visible after a folder pick, the gap matching the active date-range cutoff)
- [x] Cloud end-to-end: upload a fresh folder, click "Reload gallery", confirm the gallery opens filtered to that folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)