### PR TITLE
Cut inference cold-start: model cache + GPU zonal redundancy

### DIFF
--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -95,6 +95,25 @@ resource "google_cloud_run_v2_job" "inference" {
           name  = "GCP_PROJECT"
           value = var.project_id
         }
+        # Redirect kagglehub's cache onto the GCS-mounted volume so the
+        # SpeciesNet weights persist across job invocations.
+        env {
+          name  = "KAGGLEHUB_CACHE"
+          value = "/mnt/model-cache"
+        }
+
+        volume_mounts {
+          name       = "model-cache"
+          mount_path = "/mnt/model-cache"
+        }
+      }
+
+      volumes {
+        name = "model-cache"
+        gcs {
+          bucket    = google_storage_bucket.model_cache.name
+          read_only = false
+        }
       }
     }
   }

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -134,7 +134,7 @@ resource "terraform_data" "inference_gpu" {
   ]
 
   provisioner "local-exec" {
-    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --no-gpu-zonal-redundancy --region=${var.region} --project=${var.project_id}"
+    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --gpu-zonal-redundancy --region=${var.region} --project=${var.project_id}"
   }
 
   depends_on = [google_cloud_run_v2_job.inference]

--- a/infra/terraform/storage.tf
+++ b/infra/terraform/storage.tf
@@ -28,3 +28,23 @@ resource "google_storage_bucket_iam_member" "inference_object_admin" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.inference.email}"
 }
+
+# ── Model cache bucket ────────────────────────────────────────────────────────
+# Mounted into the inference job at /mnt/model-cache so the SpeciesNet weights
+# (~700 MB-1 GB from Kaggle Hub) are downloaded once and reused across runs
+# instead of re-fetched on every cold start.
+resource "google_storage_bucket" "model_cache" {
+  name          = "${var.project_id}-model-cache"
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_storage_bucket_iam_member" "inference_model_cache" {
+  bucket = google_storage_bucket.model_cache.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.inference.email}"
+}


### PR DESCRIPTION
## Summary
Two independent changes targeting inference job cold-start latency, after a recent run took ~5m30s end-to-end on 1 image:

| Phase | Time | Addressed by |
|---|---|---|
| GPU allocation queue | 4m 20s | **Enable zonal redundancy** |
| Container pull + Python init | 62s | (out of scope) |
| Kaggle model download + inference | <6s | **Mount model cache on GCS volume** |

### 1. Cache SpeciesNet weights on a mounted GCS volume
- The job re-downloaded the ~700 MB-1 GB SpeciesNet bundle from Kaggle Hub on every cold start.
- Adds a `${project_id}-model-cache` GCS bucket, mounts it into the inference Cloud Run Job at `/mnt/model-cache` using Cloud Run's native GCS FUSE volume support (no driver in the container; gen2 execution env already set).
- Points `KAGGLEHUB_CACHE` at the mount; `speciesnet` resolves the default `kaggle:google/speciesnet/...` model via `kagglehub`, which honors that env var ([kagglehub config.py](https://github.com/Kaggle/kagglehub/blob/main/src/kagglehub/config.py)).
- No changes to `job.py` or the Dockerfile required.

### 2. Enable GPU zonal redundancy on the inference job
- Production showed a 4m20s gap between `createTime` and `startTime` waiting for an L4 in a single zone.
- Flips `--no-gpu-zonal-redundancy` → `--gpu-zonal-redundancy` so Cloud Run can pull from any zone in `us-east4`.
- Trade-off: ~25-30% higher GPU minutes cost. Jobs are short (~1 min) and rare, so absolute impact is small.

## Cost
Storage for the model cache: ~\$0.02/month (~1 GB regional). Same-region reads to Cloud Run are free.

## Reviewer notes
- **Apply order matters for the GPU flag.** The `terraform_data.inference_gpu` provisioner re-runs only when `triggers_replace` changes (job ID, inference image). To pick up the zonal-redundancy flip on an unchanged job, run:
  ```
  terraform apply -replace=terraform_data.inference_gpu
  ```
- **First run after apply** populates the model cache (cold-start unchanged that one time).
- **Concurrent cold-start populate race** is tracked in #17; low risk for current usage.
- **Version drift:** `requirements.txt` doesn't pin `speciesnet`. A future package upgrade will populate a new versioned subdirectory in the cache; old weights become ~1 GB orphans. Worth pinning + adding a bucket lifecycle rule if this matters.

## Test plan
- [ ] `terraform plan` shows the new bucket, IAM, env var, volume mount, and updated provisioner command
- [ ] `terraform apply`, then `terraform apply -replace=terraform_data.inference_gpu`
- [ ] Trigger an inference job; confirm it succeeds and the model-cache bucket gets populated under `models/google/speciesnet/pyTorch/v4.0.2a/1/`
- [ ] Trigger a second job; confirm cold-start time drops and `createTime`→`startTime` gap is shorter than the prior 4m20s baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)