### PR TITLE
Match GPU zonal redundancy flag in deploy-inference script

### DIFF
--- a/infra/deploy-inference.ps1
+++ b/infra/deploy-inference.ps1
@@ -21,7 +21,7 @@ gcloud beta run jobs update speciesnet-inference `
   --image $IMAGE `
   --gpu=1 --gpu-type=nvidia-l4 `
   --execution-environment=gen2 `
-  --no-gpu-zonal-redundancy `
+  --gpu-zonal-redundancy `
   --region us-east4 `
   --project trackcam-viewer
 if ($LASTEXITCODE -ne 0) { throw "gcloud job update failed" }


### PR DESCRIPTION
## Summary
Follow-up to #16, which flipped the inference Cloud Run Job from `--no-gpu-zonal-redundancy` to `--gpu-zonal-redundancy` in Terraform. [deploy-inference.ps1](infra/deploy-inference.ps1) re-asserts the GPU config on every image deploy and still had the old flag — so the next time anyone ran it, the zonal-redundancy change from #16 would silently revert.

This commit landed on the same feature branch *after* #16 was merged, so it never got reviewed. Opening it as its own PR.

## Test plan
- [ ] `deploy-inference.ps1` runs successfully and the job retains zonal redundancy enabled
- [ ] `gcloud run jobs describe speciesnet-inference --region=us-east4` shows zonal redundancy on after a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)