### PR TITLE
Wire up volume + KAGGLEHUB_CACHE via gcloud provisioner; revert bad GPU zonal-redundancy flag

### DIFF
--- a/infra/deploy-inference.ps1
+++ b/infra/deploy-inference.ps1
@@ -16,12 +16,20 @@ Write-Host "==> Pushing inference image..."
 docker push $IMAGE
 if ($LASTEXITCODE -ne 0) { throw "docker push failed" }
 
-Write-Host "==> Updating job image and re-applying GPU config..."
+Write-Host "==> Updating job image and re-applying GPU + volume config..."
+# Mirrors the gcloud command in terraform_data.inference_gpu so a deploy
+# never leaves the job in a state where the provisioner-managed fields
+# (GPU, zonal redundancy, model-cache volume, KAGGLEHUB_CACHE) are stale.
 gcloud beta run jobs update speciesnet-inference `
   --image $IMAGE `
   --gpu=1 --gpu-type=nvidia-l4 `
   --execution-environment=gen2 `
   --gpu-zonal-redundancy `
+  --update-env-vars=KAGGLEHUB_CACHE=/mnt/model-cache `
+  --clear-volumes `
+  --clear-volume-mounts `
+  --add-volume=name=model-cache,type=cloud-storage,bucket=trackcam-viewer-model-cache `
+  --add-volume-mount=volume=model-cache,mount-path=/mnt/model-cache `
   --region us-east4 `
   --project trackcam-viewer
 if ($LASTEXITCODE -ne 0) { throw "gcloud job update failed" }

--- a/infra/deploy-inference.ps1
+++ b/infra/deploy-inference.ps1
@@ -24,7 +24,7 @@ gcloud beta run jobs update speciesnet-inference `
   --image $IMAGE `
   --gpu=1 --gpu-type=nvidia-l4 `
   --execution-environment=gen2 `
-  --gpu-zonal-redundancy `
+  --no-gpu-zonal-redundancy `
   --update-env-vars=KAGGLEHUB_CACHE=/mnt/model-cache `
   --clear-volumes `
   --clear-volume-mounts `

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -123,7 +123,11 @@ resource "terraform_data" "inference_gpu" {
   ]
 
   provisioner "local-exec" {
-    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --gpu-zonal-redundancy --update-env-vars=KAGGLEHUB_CACHE=/mnt/model-cache --clear-volumes --clear-volume-mounts --add-volume=name=model-cache,type=cloud-storage,bucket=${google_storage_bucket.model_cache.name} --add-volume-mount=volume=model-cache,mount-path=/mnt/model-cache --region=${var.region} --project=${var.project_id}"
+    # NOTE: --no-gpu-zonal-redundancy is not optional for GPU jobs.
+    # Per Google's error: "Currently Cloud Run jobs are unable to offer
+    # GPU enabled instances with zonal redundancy due to capacity
+    # limitations." See https://cloud.google.com/run/docs/configuring/jobs/gpu#zonal-redundancy
+    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --no-gpu-zonal-redundancy --update-env-vars=KAGGLEHUB_CACHE=/mnt/model-cache --clear-volumes --clear-volume-mounts --add-volume=name=model-cache,type=cloud-storage,bucket=${google_storage_bucket.model_cache.name} --add-volume-mount=volume=model-cache,mount-path=/mnt/model-cache --region=${var.region} --project=${var.project_id}"
   }
 
   depends_on = [google_cloud_run_v2_job.inference]

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -95,25 +95,10 @@ resource "google_cloud_run_v2_job" "inference" {
           name  = "GCP_PROJECT"
           value = var.project_id
         }
-        # Redirect kagglehub's cache onto the GCS-mounted volume so the
-        # SpeciesNet weights persist across job invocations.
-        env {
-          name  = "KAGGLEHUB_CACHE"
-          value = "/mnt/model-cache"
-        }
-
-        volume_mounts {
-          name       = "model-cache"
-          mount_path = "/mnt/model-cache"
-        }
-      }
-
-      volumes {
-        name = "model-cache"
-        gcs {
-          bucket    = google_storage_bucket.model_cache.name
-          read_only = false
-        }
+        # KAGGLEHUB_CACHE env, the model-cache volume, and the volume mount
+        # are applied via the inference_gpu provisioner below — declaring
+        # them here would race with the gcloud update that re-asserts GPU
+        # config and wipe v2-only fields.
       }
     }
   }
@@ -124,17 +109,21 @@ resource "google_cloud_run_v2_job" "inference" {
   ]
 }
 
-# node_selector (GPU config) is not yet in the Terraform provider schema.
-# Apply it via gcloud after every job create or update so the GPU config
-# is never silently wiped by a Terraform in-place update.
+# GPU config and v2-only fields (GCS volume, mount, KAGGLEHUB_CACHE env) are
+# applied via gcloud after every job create or update. The Terraform google
+# provider's in-place updates use the v1 (Knative) API view, which silently
+# drops v2-only fields like GCS volumes — so we treat this provisioner as
+# the source of truth for everything Cloud Run-Job-specific that doesn't
+# round-trip cleanly through the provider.
 resource "terraform_data" "inference_gpu" {
   triggers_replace = [
     google_cloud_run_v2_job.inference.id,
     var.inference_image,
+    google_storage_bucket.model_cache.name,
   ]
 
   provisioner "local-exec" {
-    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --gpu-zonal-redundancy --region=${var.region} --project=${var.project_id}"
+    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --gpu-zonal-redundancy --update-env-vars=KAGGLEHUB_CACHE=/mnt/model-cache --clear-volumes --clear-volume-mounts --add-volume=name=model-cache,type=cloud-storage,bucket=${google_storage_bucket.model_cache.name} --add-volume-mount=volume=model-cache,mount-path=/mnt/model-cache --region=${var.region} --project=${var.project_id}"
   }
 
   depends_on = [google_cloud_run_v2_job.inference]


### PR DESCRIPTION
## Why
PR #16 added a model-cache GCS volume to the inference Cloud Run Job via Terraform and flipped the GPU zonal-redundancy flag. After it merged, the live job ended up with:
- The model-cache bucket created (empty)
- **No volume, no mount, no `KAGGLEHUB_CACHE` env** on the job
- The `--gpu-zonal-redundancy` flag, which **isn't actually supported on Cloud Run Jobs** ([Google docs](https://cloud.google.com/run/docs/configuring/jobs/gpu#zonal-redundancy)) — confirmed by the apply error: *"Currently Cloud Run jobs are unable to offer GPU enabled instances with zonal redundancy due to capacity limitations."*

## What changed

### 1. Move volume / mount / `KAGGLEHUB_CACHE` to the gcloud provisioner
Terraform's `google_cloud_run_v2_job` in-place updates round-trip through the v1 (Knative) API view, which silently drops v2-only fields like GCS volume mounts. The `terraform_data.inference_gpu` provisioner that re-asserts GPU config runs *after* the v2 apply, and its v1 update effectively wipes the volume config.

Same shape of problem the existing GPU provisioner already solves — same fix.

- **[cloudrun.tf](infra/terraform/cloudrun.tf):** Removed `volumes`, `volume_mounts`, and the `KAGGLEHUB_CACHE` env block from the `google_cloud_run_v2_job.inference` resource. Moved them into the `terraform_data.inference_gpu` provisioner's gcloud command alongside GPU config. Added `google_storage_bucket.model_cache.name` to `triggers_replace` so bucket renames force a re-run.
- **[deploy-inference.ps1](infra/deploy-inference.ps1):** Mirrors the same flag set so an image deploy doesn't leave the job in a stale state.

### 2. Revert GPU zonal-redundancy flag
- Both the provisioner and `deploy-inference.ps1` go back to `--no-gpu-zonal-redundancy` — the only valid setting for GPU-enabled Cloud Run Jobs. The fast 4-second queue observed on a recent run was zone-availability luck, not a real fix.

## Notes
- Provisioner uses `--clear-volumes --clear-volume-mounts --add-volume=... --add-volume-mount=...` so re-runs converge to exactly one volume regardless of prior state.
- `--update-env-vars=KAGGLEHUB_CACHE=...` is additive (doesn't touch `GCS_BUCKET`/`GCP_PROJECT`).
- Closing #17 ("zonal redundancy") will not be relevant here — that issue tracked the FUSE populate race, which still applies.

## Test plan
- [ ] `terraform apply` from `infra/terraform/` succeeds end-to-end (the previous failure was the bad zonal-redundancy flag)
- [ ] `gcloud run jobs describe speciesnet-inference --region=us-east4` shows: the `model-cache` GCS volume, `/mnt/model-cache` mount, and `KAGGLEHUB_CACHE=/mnt/model-cache` in env
- [ ] First inference run after apply populates `gs://trackcam-viewer-model-cache/models/google/speciesnet/...`
- [ ] Second run skips the Kaggle download (cold start measurably faster)
- [ ] `deploy-inference.ps1` can be re-run without erasing the volume config

🤖 Generated with [Claude Code](https://claude.com/claude-code)