### PR TITLE
Gallery and species-view usability tweaks

### DIFF
--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -165,9 +165,11 @@ const filters = reactive({
   species: '',
   minConfidence: 0,
   categories: ['animal', 'human', 'vehicle', 'blank', 'unknown'],
+  categoryMode: 'any',  // 'any' | 'all'
   dateFrom: '',
   dateTo: '',
   hour: null,
+  month: null,
 })
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
@@ -230,12 +232,37 @@ function getCategory(pred) {
   return 'animal'
 }
 
+// All categories present on a prediction. Detections drive the multi-category
+// case (e.g. an image with both a human and an animal detection); the image-
+// level prediction adds blank/human/vehicle when it disagrees with detections,
+// and 'animal' when the species classifier produced a name without a matching
+// detection box. Used by the category filter's "all of" mode.
+function getCategories(pred) {
+  const cats = new Set()
+  for (const d of (pred.detections ?? [])) {
+    if (d.category === '1') cats.add('animal')
+    else if (d.category === '2') cats.add('human')
+    else if (d.category === '3') cats.add('vehicle')
+  }
+  const name = pred.prediction?.common_name?.toLowerCase()
+  if (name === 'blank') cats.add('blank')
+  else if (name === 'human') cats.add('human')
+  else if (name === 'vehicle') cats.add('vehicle')
+  else if (name && cats.size === 0) cats.add('animal')
+  if (cats.size === 0) cats.add('unknown')
+  return cats
+}
+
 const filteredPredictions = computed(() => {
   const from = filters.dateFrom
   const to   = filters.dateTo
   return predictions.value.filter(p => {
-    const cat = getCategory(p)
-    if (!filters.categories.includes(cat)) return false
+    if (filters.categories.length === 0) return false
+    const cats = getCategories(p)
+    const matches = filters.categoryMode === 'all'
+      ? filters.categories.every(c => cats.has(c))
+      : filters.categories.some(c => cats.has(c))
+    if (!matches) return false
     if (filters.folder && p.folder !== filters.folder) return false
     if (filters.species && p.prediction?.common_name !== filters.species) return false
     if (filters.species) {
@@ -251,6 +278,10 @@ const filteredPredictions = computed(() => {
     if (filters.hour !== null) {
       const h = predHour(p)
       if (h !== filters.hour) return false
+    }
+    if (filters.month !== null) {
+      const m = predMonth(p)
+      if (m !== filters.month) return false
     }
     if (from || to) {
       const date = predDate(p)
@@ -332,6 +363,11 @@ function predHour(p) {
   return ts.length >= 10 ? parseInt(ts.slice(8, 10), 10) : -1
 }
 
+function predMonth(p) {
+  const ts = predTs(p)
+  return ts.length >= 6 ? parseInt(ts.slice(4, 6), 10) - 1 : -1
+}
+
 function openModal(image) { selectedImage.value = image }
 
 function onImageDeleted(image) {
@@ -378,9 +414,10 @@ async function doDelete() {
   }
 }
 
-function applyHistogramFilter({ species, hour }) {
+function applyHistogramFilter({ species, hour = null, month = null }) {
   filters.species = species
   filters.hour    = hour
+  filters.month   = month
   view.value      = 'gallery'
 }
 

--- a/webapp/frontend/src/components/FilterBar.vue
+++ b/webapp/frontend/src/components/FilterBar.vue
@@ -10,10 +10,40 @@
 
     <div class="filterbar__section">
       <label class="filterbar__label">Species</label>
-      <select class="filterbar__select" :value="filters.species" @change="emit('update', { species: $event.target.value })">
-        <option value="">All species</option>
-        <option v-for="s in species" :key="s" :value="s">{{ capitalize(s) }}</option>
-      </select>
+      <div class="filterbar__combo">
+        <input
+          ref="speciesInput"
+          v-model="speciesQuery"
+          type="text"
+          class="filterbar__select"
+          placeholder="All species"
+          @focus="onSpeciesFocus"
+          @keydown.esc="closeSpecies"
+          @keydown.enter.prevent="commitFirstMatch"
+        />
+        <button
+          v-if="filters.species"
+          type="button"
+          class="filterbar__combo-clear"
+          title="Clear species filter"
+          @mousedown.prevent="selectSpecies('')"
+        >✕</button>
+        <ul v-if="speciesOpen" class="filterbar__combo-list">
+          <li
+            class="filterbar__combo-item"
+            :class="{ 'is-active': filters.species === '' }"
+            @mousedown.prevent="selectSpecies('')"
+          >All species</li>
+          <li
+            v-for="s in filteredSpecies"
+            :key="s"
+            class="filterbar__combo-item"
+            :class="{ 'is-active': filters.species === s }"
+            @mousedown.prevent="selectSpecies(s)"
+          >{{ capitalize(s) }}</li>
+          <li v-if="filteredSpecies.length === 0" class="filterbar__combo-empty">No matches</li>
+        </ul>
+      </div>
     </div>
 
     <div class="filterbar__section">
@@ -52,6 +82,26 @@
 
     <div class="filterbar__section">
       <label class="filterbar__label">Category</label>
+      <div class="filterbar__mode">
+        <label class="filterbar__mode-radio">
+          <input
+            type="radio"
+            value="any"
+            :checked="filters.categoryMode !== 'all'"
+            @change="emit('update', { categoryMode: 'any' })"
+          />
+          any of
+        </label>
+        <label class="filterbar__mode-radio">
+          <input
+            type="radio"
+            value="all"
+            :checked="filters.categoryMode === 'all'"
+            @change="emit('update', { categoryMode: 'all' })"
+          />
+          all of
+        </label>
+      </div>
       <div class="filterbar__checks">
         <label v-for="cat in CATEGORIES" :key="cat.key" class="filterbar__check">
           <input
@@ -72,6 +122,14 @@
       </div>
     </div>
 
+    <div v-if="filters.month !== null" class="filterbar__section">
+      <label class="filterbar__label">Month filter</label>
+      <div class="filterbar__chip">
+        {{ MONTH_NAMES[filters.month] }}
+        <button class="filterbar__chip-clear" @click="emit('update', { month: null })">✕</button>
+      </div>
+    </div>
+
     <div class="filterbar__footer">
       <span class="filterbar__count">{{ filtered }} / {{ total }}</span>
       <button class="filterbar__clear" @click="clearFilters">Clear</button>
@@ -80,6 +138,8 @@
 </template>
 
 <script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+
 const props = defineProps({
   species: Array,
   folders: { type: Array, default: () => [] },
@@ -92,6 +152,56 @@ const props = defineProps({
 
 const emit = defineEmits(['update'])
 
+const speciesInput = ref(null)
+const speciesQuery = ref(capitalize(props.filters.species))
+const speciesOpen  = ref(false)
+
+watch(() => props.filters.species, (sp) => {
+  if (!speciesOpen.value) speciesQuery.value = capitalize(sp)
+})
+
+const filteredSpecies = computed(() => {
+  const q = speciesQuery.value.trim().toLowerCase()
+  const selectedDisplay = capitalize(props.filters.species).toLowerCase()
+  // When the input still shows the current selection, list everything so the
+  // user can browse without having to clear first.
+  if (!q || q === selectedDisplay) return props.species
+  return props.species.filter(s => s.toLowerCase().includes(q))
+})
+
+function onSpeciesFocus(e) {
+  speciesOpen.value = true
+  e.target.select()
+}
+
+function closeSpecies() {
+  speciesOpen.value = false
+  speciesQuery.value = capitalize(props.filters.species)
+  speciesInput.value?.blur()
+}
+
+function selectSpecies(s) {
+  emit('update', { species: s })
+  speciesQuery.value = capitalize(s)
+  speciesOpen.value = false
+  speciesInput.value?.blur()
+}
+
+function commitFirstMatch() {
+  const match = filteredSpecies.value[0]
+  if (match) selectSpecies(match)
+  else selectSpecies('')
+}
+
+function onDocClick(e) {
+  if (!speciesOpen.value) return
+  if (speciesInput.value?.parentElement?.contains(e.target)) return
+  closeSpecies()
+}
+
+onMounted(() => document.addEventListener('mousedown', onDocClick))
+onBeforeUnmount(() => document.removeEventListener('mousedown', onDocClick))
+
 const CATEGORIES = [
   { key: 'animal',  label: 'Animal' },
   { key: 'human',   label: 'Human' },
@@ -99,6 +209,8 @@ const CATEGORIES = [
   { key: 'blank',   label: 'Blank' },
   { key: 'unknown', label: 'Unknown' },
 ]
+
+const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
 
 function capitalize(s) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : s
@@ -117,9 +229,11 @@ function clearFilters() {
     species: '',
     minConfidence: 0,
     categories: CATEGORIES.map(c => c.key),
+    categoryMode: 'any',
     dateFrom: props.dateFromMin ?? '',
     dateTo: props.dateToMax ?? '',
     hour: null,
+    month: null,
   })
 }
 </script>
@@ -165,6 +279,62 @@ function clearFilters() {
   color: var(--text);
   padding: 6px 10px;
   width: 100%;
+  font: inherit;
+}
+.filterbar__select:focus {
+  outline: none;
+  border-color: var(--accent, #2d7d46);
+}
+
+.filterbar__combo {
+  position: relative;
+}
+.filterbar__combo-clear {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 2px 4px;
+}
+.filterbar__combo-clear:hover { color: var(--text); }
+.filterbar__combo-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 2px 0 0;
+  padding: 2px 0;
+  list-style: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.35);
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 30;
+}
+.filterbar__combo-item {
+  padding: 5px 10px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+.filterbar__combo-item:hover { background: var(--surface2); }
+.filterbar__combo-item.is-active {
+  background: var(--accent, #2d7d46);
+  color: white;
+}
+.filterbar__combo-empty {
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .filterbar__range {
@@ -186,6 +356,25 @@ function clearFilters() {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.filterbar__mode {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text);
+}
+.filterbar__mode-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+.filterbar__mode-radio input[type="radio"] {
+  accent-color: var(--animal);
+  width: 13px;
+  height: 13px;
+  cursor: pointer;
 }
 
 .filterbar__check {

--- a/webapp/frontend/src/components/ImageGallery.vue
+++ b/webapp/frontend/src/components/ImageGallery.vue
@@ -26,9 +26,9 @@
           <div class="gallery__badge-row">
             <span
               v-for="det in detectionCounts(img)"
-              :key="det.label"
-              :class="`badge badge--${det.label}`"
-            >{{ det.label +": " }} {{ det.count}} </span>
+              :key="`${det.category}|${det.name}`"
+              :class="`badge badge--${det.category}`"
+            >{{ capitalize(det.name) }}: {{ det.count }}</span>
           </div>
         </button>
         <button
@@ -77,14 +77,25 @@ function formatTime(d) {
 // category key matches CSS badge classes: animal / human / vehicle
 const CATEGORY_LABEL = { '1': 'animal', '2': 'human', '3': 'vehicle' }
 
+function capitalize(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s
+}
+
+// One badge per (category, species) pair. Animal detections fall back to the
+// generic "animal" name when they have no species label; human/vehicle use
+// the category itself since they aren't speciated.
 function detectionCounts(img) {
-  const counts = {}
+  const counts = new Map()
   for (const det of img.detections ?? []) {
     if (det.conf < 0.7) continue
-    const label = CATEGORY_LABEL[det.category] ?? det.label
-    counts[label] = (counts[label] ?? 0) + 1
+    const category = CATEGORY_LABEL[det.category] ?? 'unknown'
+    const name = (category === 'animal' && det.label) ? det.label : category
+    const key = `${category}|${name}`
+    const existing = counts.get(key)
+    if (existing) existing.count++
+    else counts.set(key, { name, category, count: 1 })
   }
-  return Object.entries(counts).map(([label, count]) => ({ label, count }))
+  return [...counts.values()]
 }
 </script>
 

--- a/webapp/frontend/src/components/SpeciesView.vue
+++ b/webapp/frontend/src/components/SpeciesView.vue
@@ -74,6 +74,7 @@
                         @mouseenter="barHover = { id: `${card.key}-m${m}`, label: MONTH_NAMES[m], count: n, x: $event.clientX, y: $event.clientY }"
                         @mousemove="barHover = { ...barHover, x: $event.clientX, y: $event.clientY }"
                         @mouseleave="barHover = null"
+                        @click="emit('filter', { species: card.rawName, month: m })"
                       />
                     </svg>
                     <div class="histogram__labels">
@@ -257,23 +258,23 @@ const speciesCards = computed(() => {
 
   const cards = []
   for (const [commonName, preds] of groups.entries()) {
-    const sorted = [...preds].sort((a, b) => {
-      const sa = a.prediction_score ?? 0
-      const sb = b.prediction_score ?? 0
-      if (sb !== sa) return sb - sa
-      const ta = timestampOf(a)
-      const tb = timestampOf(b)
-      return tb.localeCompare(ta)
-    })
-    const top = sorted.slice(0, 5).map(pred => {
+    const ranked = preds.map(pred => {
       const det = bestDetection(pred)
-      return {
-        pred,
-        cropPath: det?.crop_gcs_path || null,
-        bbox: det?.bbox || null,
-        when: formatTimestamp(timestampOf(pred)),
-      }
+      const [, , bw = 0, bh = 0] = det?.bbox || []
+      const area  = bw * bh
+      const score = pred.prediction_score ?? 0
+      return { pred, det, rank: area * score }
     })
+    ranked.sort((a, b) => {
+      if (b.rank !== a.rank) return b.rank - a.rank
+      return timestampOf(b.pred).localeCompare(timestampOf(a.pred))
+    })
+    const top = ranked.slice(0, 5).map(({ pred, det }) => ({
+      pred,
+      cropPath: det?.crop_gcs_path || null,
+      bbox: det?.bbox || null,
+      when: formatTimestamp(timestampOf(pred)),
+    }))
     const hours  = new Array(24).fill(0)
     const months = new Array(12).fill(0)
     for (const pred of preds) {


### PR DESCRIPTION
## Summary

A bundle of small UX improvements across the gallery, filter sidebar, and species view.

- **Month-of-year histogram is clickable.** Clicking a bar in the Month-of-Year histogram on a species card now applies a `month` filter, mirroring the existing Time-of-Day click-to-filter. The filter sidebar shows a clearable Month chip alongside the Hour chip.
- **Top crops rank by prominence × confidence.** The 5 crops shown on each species card now sort by `bbox area × prediction_score` (descending), with recency as the tiebreaker — so big, confident detections surface ahead of tiny high-confidence ones.
- **Searchable species filter.** The Species `<select>` in the gallery sidebar is now a typeable combobox: focus selects all so you can replace inline, typing filters the dropdown, Enter commits the first match, Esc cancels, and a ✕ clears the filter.
- **Any-of / all-of category filter.** The Category section gains "any of" / "all of" radios. The predicate compares against the full set of categories an image carries (derived from its detections plus image-level prediction), so "all of: animal + human" returns only images that contain both.
- **Per-species badges in gallery thumbnails.** Animal detections no longer collapse under a single "animal" badge — each species gets its own animal-colored badge (e.g. `Coyote: 2`). Humans/vehicles still bucket under their category since they aren't speciated.

## Test plan

- [ ] Click a Month-of-Year bar in the species view — gallery opens filtered to that species and month, chip is shown and clearable.
- [ ] Click a Time-of-Day bar — still works as before; Hour chip clears independently.
- [ ] Verify species cards show the largest+most-confident crops first.
- [ ] In the species combobox: type to filter, press Enter to commit the top match, Esc to cancel, ✕ to clear, and confirm an externally-set species (e.g. via histogram click) reflects in the input.
- [ ] Toggle "any of" → "all of" with multiple categories selected — confirm only images with all selected categories remain.
- [ ] Verify gallery thumbnails show one badge per species, with correct counts and colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)