### PR TITLE
Bake SpeciesNet model into the inference image

### DIFF
--- a/infra/Dockerfile.inference
+++ b/infra/Dockerfile.inference
@@ -45,6 +45,14 @@ RUN python -m pip install --no-cache-dir -r requirements.txt \
     && find "$SITE" -type d -name 'tests' -prune -exec rm -rf {} + \
     && find "$SITE" -name '*.pyc' -delete
 
+# Bake the SpeciesNet model into the image. Each cold-started container
+# already pays the image pull, so amortizing the model bytes there beats
+# downloading them from Kaggle Hub (or reading them through GCS FUSE) on
+# every job. See infra/inference/prefetch_models.py for what's fetched.
+ENV KAGGLEHUB_CACHE=/opt/kagglehub
+COPY prefetch_models.py ./
+RUN python prefetch_models.py && rm prefetch_models.py
+
 COPY job.py ./
 
 ENTRYPOINT ["python", "job.py"]

--- a/infra/deploy-inference.ps1
+++ b/infra/deploy-inference.ps1
@@ -16,20 +16,18 @@ Write-Host "==> Pushing inference image..."
 docker push $IMAGE
 if ($LASTEXITCODE -ne 0) { throw "docker push failed" }
 
-Write-Host "==> Updating job image and re-applying GPU + volume config..."
+Write-Host "==> Updating job image and re-applying GPU config..."
 # Mirrors the gcloud command in terraform_data.inference_gpu so a deploy
-# never leaves the job in a state where the provisioner-managed fields
-# (GPU, zonal redundancy, model-cache volume, KAGGLEHUB_CACHE) are stale.
+# never leaves the GPU config stale. Volumes are intentionally cleared —
+# the SpeciesNet model is now baked into the image (see Dockerfile.inference
+# + prefetch_models.py).
 gcloud beta run jobs update speciesnet-inference `
   --image $IMAGE `
   --gpu=1 --gpu-type=nvidia-l4 `
   --execution-environment=gen2 `
   --no-gpu-zonal-redundancy `
-  --update-env-vars=KAGGLEHUB_CACHE=/mnt/model-cache `
   --clear-volumes `
   --clear-volume-mounts `
-  --add-volume=name=model-cache,type=cloud-storage,bucket=trackcam-viewer-model-cache `
-  --add-volume-mount=volume=model-cache,mount-path=/mnt/model-cache `
   --region us-east4 `
   --project trackcam-viewer
 if ($LASTEXITCODE -ne 0) { throw "gcloud job update failed" }

--- a/infra/inference/prefetch_models.py
+++ b/infra/inference/prefetch_models.py
@@ -1,0 +1,32 @@
+"""
+Pre-download SpeciesNet model artifacts at image-build time so the inference
+job doesn't pay the ~1 GB Kaggle Hub + GitHub fetch on every cold start.
+
+Pulls:
+  - The Kaggle bundle (classifier weights, taxonomy, geofence, info.json)
+  - The MegaDetector .pt that speciesnet's info.json references via a GitHub
+    URL — speciesnet would otherwise lazy-fetch this on first run_model call
+
+KAGGLEHUB_CACHE must be set before invoking; the resolved files end up under
+$KAGGLEHUB_CACHE/models/google/speciesnet/pyTorch/<version>/<rev>/
+"""
+import json
+import os
+import urllib.request
+
+import kagglehub
+
+MODEL = "google/speciesnet/pyTorch/v4.0.2a/1"
+
+base = kagglehub.model_download(MODEL)
+info = json.load(open(os.path.join(base, "info.json")))
+
+detector_url = info.get("detector")
+if detector_url:
+    fname = detector_url.replace(":", "_").replace("/", "_")
+    target = os.path.join(base, fname)
+    if not os.path.exists(target):
+        print(f"prefetch: fetching detector from {detector_url}")
+        urllib.request.urlretrieve(detector_url, target)
+
+print(f"prefetch: model ready under {base}")

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -109,25 +109,21 @@ resource "google_cloud_run_v2_job" "inference" {
   ]
 }
 
-# GPU config and v2-only fields (GCS volume, mount, KAGGLEHUB_CACHE env) are
-# applied via gcloud after every job create or update. The Terraform google
-# provider's in-place updates use the v1 (Knative) API view, which silently
-# drops v2-only fields like GCS volumes — so we treat this provisioner as
-# the source of truth for everything Cloud Run-Job-specific that doesn't
-# round-trip cleanly through the provider.
+# GPU config isn't yet exposed through the Terraform provider schema, so we
+# re-assert it via gcloud after every job create or update.
+#
+# --no-gpu-zonal-redundancy is the only valid setting for GPU jobs today:
+# "Currently Cloud Run jobs are unable to offer GPU enabled instances with
+# zonal redundancy due to capacity limitations."
+# https://cloud.google.com/run/docs/configuring/jobs/gpu#zonal-redundancy
 resource "terraform_data" "inference_gpu" {
   triggers_replace = [
     google_cloud_run_v2_job.inference.id,
     var.inference_image,
-    google_storage_bucket.model_cache.name,
   ]
 
   provisioner "local-exec" {
-    # NOTE: --no-gpu-zonal-redundancy is not optional for GPU jobs.
-    # Per Google's error: "Currently Cloud Run jobs are unable to offer
-    # GPU enabled instances with zonal redundancy due to capacity
-    # limitations." See https://cloud.google.com/run/docs/configuring/jobs/gpu#zonal-redundancy
-    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --no-gpu-zonal-redundancy --update-env-vars=KAGGLEHUB_CACHE=/mnt/model-cache --clear-volumes --clear-volume-mounts --add-volume=name=model-cache,type=cloud-storage,bucket=${google_storage_bucket.model_cache.name} --add-volume-mount=volume=model-cache,mount-path=/mnt/model-cache --region=${var.region} --project=${var.project_id}"
+    command = "gcloud beta run jobs update ${google_cloud_run_v2_job.inference.name} --gpu=1 --gpu-type=nvidia-l4 --execution-environment=gen2 --no-gpu-zonal-redundancy --clear-volumes --clear-volume-mounts --region=${var.region} --project=${var.project_id}"
   }
 
   depends_on = [google_cloud_run_v2_job.inference]

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -13,13 +13,17 @@ terraform {
 }
 
 provider "google" {
-  project = var.project_id
-  region  = var.region
+  project               = var.project_id
+  region                = var.region
+  user_project_override = true
+  billing_project       = var.project_id
 }
 
 provider "google-beta" {
-  project = var.project_id
-  region  = var.region
+  project               = var.project_id
+  region                = var.region
+  user_project_override = true
+  billing_project       = var.project_id
 }
 
 # Enable all required GCP APIs


### PR DESCRIPTION
## Why
The GCS-FUSE-mounted model cache from #16/#19 turned out to be a cold-start *regression*. Comparing the recent runs:

| Run | Setup | Cold start (startTime → \"AI model ready\") |
|---|---|---|
| `446x8` | no cache | 62 sec |
| `k5z9q` | no cache | 62 sec |
| `9wqr6` | FUSE cache | **92 sec** |
| `zfk6m` | FUSE cache | **102 sec** |

Two contributors:
- ~16 sec spent on GCSFuse mount + config dump before Python starts
- Streaming ~1 GB of weights through FUSE during model load is slower than the ~10 sec Kaggle direct download it replaced

The cache populated correctly (verified \`gs://trackcam-viewer-model-cache/models/google/speciesnet/...\` had the full bundle including the MegaDetector .pt) — it just wasn't a win in practice.

## What changed
- **[prefetch_models.py](infra/inference/prefetch_models.py):** new build-time script that runs \`kagglehub.model_download\`, then reads \`info.json\` to fetch the MegaDetector .pt that speciesnet's run_model would otherwise lazy-fetch.
- **[Dockerfile.inference](infra/Dockerfile.inference):** \`ENV KAGGLEHUB_CACHE=/opt/kagglehub\` + \`RUN python prefetch_models.py\` so the model is baked into a Docker layer.
- **[cloudrun.tf](infra/terraform/cloudrun.tf):** stripped the volume mount, volume_mounts, and \`KAGGLEHUB_CACHE\` env-var flags from the gcloud provisioner. Kept \`--clear-volumes --clear-volume-mounts\` so applying this PR also unmounts the bucket from the live job.
- **[deploy-inference.ps1](infra/deploy-inference.ps1):** mirrors the same flags.
- **[main.tf](infra/terraform/main.tf):** \`user_project_override = true\` + \`billing_project\` on both providers — required for \`terraform apply\` to work with user ADC credentials (was hit during the prior apply).

## Trade-offs
- **Image size grows by ~1 GB.** Cloud Run caches images per-instance, so a warm container reuses the layer; cold pulls are slower but only happen once per revision per host.
- **Build time grows by ~30-60 sec** (one Kaggle download per build).
- **Model version is pinned by the Dockerfile.** The path \`kaggle:google/speciesnet/pyTorch/v4.0.2a/1\` is hardcoded in [prefetch_models.py](infra/inference/prefetch_models.py). Bumping speciesnet now requires changing both \`requirements.txt\` and that constant — worth a follow-up if it churns.

## Follow-ups (not in this PR)
- Delete the now-unused \`gs://trackcam-viewer-model-cache\` bucket (left in terraform to avoid \`force_destroy\` complications on a non-empty bucket).
- Pin \`speciesnet\` in [requirements.txt](infra/inference/requirements.txt) so the bundled package version always matches the prefetched model version.

## Test plan
- [ ] \`docker build -f infra/Dockerfile.inference\` succeeds and the resulting image contains \`/opt/kagglehub/models/google/speciesnet/pyTorch/v4.0.2a/1/{always_crop_*.pt, https___github.com_*.pt, info.json, ...}\`
- [ ] \`infra/deploy-inference.ps1\` pushes the new image and updates the job
- [ ] \`terraform apply\` runs cleanly (provisioner fires due to image change)
- [ ] \`gcloud run jobs describe speciesnet-inference\` shows no GCS volumes, no \`KAGGLEHUB_CACHE\` env (now baked into the image's ENV), GPU config preserved
- [ ] Trigger an inference run; cold start (\`startTime → \"AI model ready\"\`) should be back near the 62 sec baseline (or below, since the Kaggle download is gone too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)