### PR TITLE
Parallelize blob I/O in the inference job

### DIFF
--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -23,6 +24,13 @@ from PIL import Image, ImageOps
 CROP_CONF_THRESHOLD = 0.2
 CROP_MAX_DIM        = 512
 CROP_JPEG_QUALITY   = 85
+
+# GCS round-trip latency (~50-200ms per blob) dominates large-batch wall
+# time — sequential I/O made a 513-image run take ~14 minutes on top of
+# inference. 16 workers cuts that to single-digit minutes without
+# pressuring the per-instance memory budget.
+DOWNLOAD_WORKERS = 16
+UPLOAD_WORKERS   = 16
 
 # The web backend fires run_job at upload-prepare time, so the container
 # often starts cold-starting BEFORE the browser has finished PUT-ing all
@@ -146,17 +154,27 @@ def main():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # ── Download images from GCS ──────────────────────────────────────────
-        local_paths = []
+        # Sequential downloads were the dominant cost on large batches:
+        # GCS round-trip latency (~50-200ms) stacked across 500 blobs is
+        # several minutes. Parallelize so wall time scales by total bytes
+        # rather than blob count.
+        local_paths: list[str] = []
         path_map: dict[str, str] = {}  # local_path -> gcs_path
 
-        for i, gcs_path in enumerate(files):
+        def _download_one(gcs_path: str) -> tuple[str, str]:
             filename   = Path(gcs_path).name
             local_path = os.path.join(tmpdir, filename)
             bucket.blob(gcs_path).download_to_filename(local_path)
-            local_paths.append(local_path)
-            path_map[local_path] = gcs_path
-            if (i + 1) % 20 == 0 or (i + 1) == len(files):
-                set_status("running", f"Downloaded {i+1}/{len(files)} images…")
+            return gcs_path, local_path
+
+        with ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as ex:
+            done = 0
+            for gcs_path, local_path in ex.map(_download_one, files):
+                local_paths.append(local_path)
+                path_map[local_path] = gcs_path
+                done += 1
+                if done % 20 == 0 or done == len(files):
+                    set_status("running", f"Downloaded {done}/{len(files)} images…")
 
         # ── Build instances JSON ──────────────────────────────────────────────
         instances = []
@@ -224,17 +242,69 @@ def main():
             set_status("error", f"SpeciesNet exited with code {process.returncode}")
             raise SystemExit(1)
 
-        # ── Write predictions to Firestore ────────────────────────────────────
-        set_status("running", "Saving predictions to database…")
-
         with open(predictions_file, encoding="utf-8") as f:
             output = json.load(f)
+
+        folder = job_doc.get("folder", "")
+
+        # ── Generate crops (CPU) then upload in parallel (I/O) ────────────────
+        # Splitting these phases lets us serialize the cheap PIL work and
+        # batch the slow GCS round-trips into a thread pool — same trick
+        # the download loop above uses, applied to the larger of the two
+        # write paths (one upload per detection above the conf threshold).
+        crop_jobs: list[tuple[str, str, dict]] = []  # (local_path, gcs_path, det)
+        for pred in output.get("predictions", []):
+            local_fp = pred["filepath"]
+            gcs_path = path_map.get(local_fp, local_fp)
+            filename = Path(gcs_path).name
+            detections = pred.get("detections", [])
+            source_image = None
+            for idx, det in enumerate(detections):
+                if det.get("conf", 0) < CROP_CONF_THRESHOLD or not det.get("bbox"):
+                    continue
+                if source_image is None:
+                    try:
+                        # Apply EXIF orientation so portrait-mode photos crop
+                        # in the orientation the browser displays them in.
+                        # Without this, crops come out 90°/180° rotated for
+                        # any image whose camera embedded a non-default
+                        # Orientation tag (very common on trail cams).
+                        source_image = ImageOps.exif_transpose(Image.open(local_fp))
+                    except Exception as exc:
+                        log.append(f"crop: could not open {local_fp}: {exc}")
+                        break
+                stem = Path(filename).stem
+                crop_filename = f"{stem}_detection_{idx + 1}.jpg"
+                crop_local = os.path.join(tmpdir, crop_filename)
+                try:
+                    _save_crop(source_image, det["bbox"], crop_local)
+                except Exception as exc:
+                    log.append(f"crop: failed for {filename} det {idx}: {exc}")
+                    continue
+                crop_gcs_path = f"crops/{uid}/{folder}/{crop_filename}"
+                crop_jobs.append((crop_local, crop_gcs_path, det))
+            if source_image is not None:
+                source_image.close()
+
+        if crop_jobs:
+            set_status("running", f"Uploading {len(crop_jobs)} crop(s)…")
+
+            def _upload_crop(job: tuple[str, str, dict]) -> None:
+                local, remote, det = job
+                bucket.blob(remote).upload_from_filename(local, content_type="image/jpeg")
+                det["crop_gcs_path"] = remote
+
+            with ThreadPoolExecutor(max_workers=UPLOAD_WORKERS) as ex:
+                for _ in ex.map(_upload_crop, crop_jobs):
+                    pass
+
+        # ── Write predictions to Firestore ────────────────────────────────────
+        set_status("running", "Saving predictions to database…")
 
         batch = db.batch()
         batch_count = 0
         count = 0
         now = _now()
-        folder = job_doc.get("folder", "")
 
         # Summary data shown in the upload dialog when the job completes.
         # Category names mirror the gallery badges (animal/human/vehicle/blank).
@@ -262,36 +332,6 @@ def main():
                     top5.append({**_parse_label(cls), "score": round(score, 4)})
 
             detections = pred.get("detections", [])
-            source_image = None
-            for idx, det in enumerate(detections):
-                if det.get("conf", 0) < CROP_CONF_THRESHOLD or not det.get("bbox"):
-                    continue
-                if source_image is None:
-                    try:
-                        # Apply EXIF orientation so portrait-mode photos crop
-                        # in the orientation the browser displays them in.
-                        # Without this, crops come out 90°/180° rotated for
-                        # any image whose camera embedded a non-default
-                        # Orientation tag (very common on trail cams).
-                        source_image = ImageOps.exif_transpose(Image.open(local_fp))
-                    except Exception as exc:
-                        log.append(f"crop: could not open {local_fp}: {exc}")
-                        break
-                stem = Path(filename).stem
-                crop_filename = f"{stem}_detection_{idx + 1}.jpg"
-                crop_local = os.path.join(tmpdir, crop_filename)
-                try:
-                    _save_crop(source_image, det["bbox"], crop_local)
-                except Exception as exc:
-                    log.append(f"crop: failed for {filename} det {idx}: {exc}")
-                    continue
-                crop_gcs_path = f"crops/{uid}/{folder}/{crop_filename}"
-                bucket.blob(crop_gcs_path).upload_from_filename(
-                    crop_local, content_type="image/jpeg"
-                )
-                det["crop_gcs_path"] = crop_gcs_path
-            if source_image is not None:
-                source_image.close()
 
             doc = {
                 "gcs_path":          gcs_path,


### PR DESCRIPTION
## Why
Large batches were spending almost all their wall time on sequential GCS I/O, not on inference:

| Run | Images | Total runtime (after cold start) | Per-image |
|---|---|---|---|
| `s6kw7` | 20 | 5s | 0.25s |
| `ckgvl` | 57 | 72s | 1.26s |
| `8fflg` | 478 | 471s | 0.98s |
| `tbwhs` | 478 | 732s | 1.53s |
| `2gpf2` | 513 | 884s | **1.72s** |

SpeciesNet inference itself runs at ~0.1s/image on the L4 — the rest is GCS round-trip latency stacked across two sequential for-loops in [job.py](infra/inference/job.py): one downloading source images, one uploading per-detection crops. The 513-image run produced 1145 detections, so 513 + 1145 = 1658 sequential blob ops, each costing 50-200ms.

## What changed
[infra/inference/job.py](infra/inference/job.py):

1. **Download loop** is now a `ThreadPoolExecutor.map` with 16 workers. Progress reporting (\"Downloaded N/M images…\") still fires on completion order, every 20 finishes.
2. **Crop pipeline** is split into two phases:
   - **Sequential CPU phase**: walk predictions, lazily open each source image with PIL, generate crops to local disk. This was already cheap; keeping it serial avoids contention on a single PIL image object across threads.
   - **Parallel I/O phase**: a 16-worker pool uploads all crop JPEGs and mutates each `det` dict with its `crop_gcs_path`. Wait for the pool to drain before the Firestore loop starts so every doc has the right crop reference.
3. **Firestore write loop** is now decoupled from crop logic — drops a chunk of conditional code that's no longer relevant on that path.

## Expected impact
- 500-image batch: ~5-10x faster on the I/O phases. The 14-minute tail on `2gpf2` should drop to ~1-3 minutes.
- Small batches (≤25 images): pool spinup is a few hundred ms, well below cold-start noise.
- No change to small-batch hot paths beyond the harmless dict typing.

## Notes
- Worker count (16) is conservative. GCS easily handles 100+ concurrent ops; could tune up later if profiling shows the bottleneck has moved elsewhere.
- The download loop preserves the existing footgun where two GCS objects with the same basename overwrite each other locally — out of scope here, but worth a follow-up if it ever bites.
- `count` and `summary_images` order may differ slightly because download completion order is no longer input order, but no caller depends on it.

## Test plan
- [x] Existing single-image and small-batch (~20) runs still complete cleanly with no per-image regression
- [x] A 100+ image batch shows materially shorter wall time vs. recent baselines
- [x] Firestore docs all have correct `detections[].crop_gcs_path` after the run
- [x] Crop GCS objects exist at \`crops/<uid>/<folder>/<stem>_detection_<n>.jpg\` for every above-threshold detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)