### PR TITLE
Surface phase timing — unbuffer Python stdout

### DIFF
--- a/infra/Dockerfile.inference
+++ b/infra/Dockerfile.inference
@@ -55,4 +55,8 @@ RUN python prefetch_models.py && rm prefetch_models.py
 
 COPY job.py ./
 
-ENTRYPOINT ["python", "job.py"]
+# -u disables stdout buffering so set_status() prints land in Cloud Logging
+# at their actual time rather than bunched at process exit. Phase timing is
+# the only way to tell where a slow run is spending its wall-clock — without
+# this, every job.py log line in a batch shows the same flush timestamp.
+ENTRYPOINT ["python", "-u", "job.py"]

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -224,6 +224,11 @@ def main():
             set_status("error", f"SpeciesNet exited with code {process.returncode}")
             raise SystemExit(1)
 
+        # Marker so phase timing in Cloud Logging shows speciesnet end ≠
+        # crop/firestore work (the existing set_status calls already mark
+        # the start of each downstream phase).
+        set_status("running", "SpeciesNet complete — building crops…")
+
         # ── Write predictions to Firestore ────────────────────────────────────
         set_status("running", "Saving predictions to database…")
 


### PR DESCRIPTION
## Why
Every \`set_status()\` log line in [job.py](infra/inference/job.py) currently lands in Cloud Logging with the same flush-at-exit timestamp, which means we can't tell where a slow run is actually spending its time. From the most recent 495-image run:

\`\`\`
2026-04-27T19:40:36.089502Z  [running] AI model ready ...
2026-04-27T19:40:36.089525Z  [running] Waiting for uploads ...
2026-04-27T19:40:36.089546Z  [running] Downloading 495 image(s) ...
2026-04-27T19:40:36.089622Z  [running] Running SpeciesNet inference ...
2026-04-27T19:40:36.089626Z  [running] Uploading 1266 crop(s) ...
2026-04-27T19:40:36.089631Z  [done] Done — 495 prediction(s) saved
\`\`\`

All within 130 microseconds — clearly buffered. Cause: Python 3 block-buffers stdout when it's a non-TTY pipe (which it is in Cloud Run), and the existing \`ENTRYPOINT ["python", "job.py"]\` doesn't force line buffering.

## What changed
- **[Dockerfile.inference](infra/Dockerfile.inference):** \`["python", "-u", "job.py"]\` — \`-u\` disables stdout/stderr buffering for the whole job.
- **[job.py](infra/inference/job.py):** added one extra \`set_status(\"running\", \"SpeciesNet complete — building crops…\")\` so the speciesnet→crops transition gets its own timestamp instead of being inferred from the surrounding markers.

## How to use this
After merging + redeploying:

1. Run a representative batch
2. Pull the logs filtered to that execution's \`set_status\` lines
3. Each phase boundary shows up as a distinct Cloud Logging timestamp:
   - \`AI model ready\` → \`Waiting for uploads\` → \`Downloading\` → per-20 download progress → \`Running SpeciesNet inference\` → \`SpeciesNet complete\` → \`Uploading N crop(s)\` → \`Saving predictions to database\` → \`Done\`
4. Subtract pairs to get phase durations.

This is a measurement tool, not a fix — the actual question (\"is speciesnet inference the bottleneck at this scale?\") gets answered by the resulting timestamps.

## Notes
- Independent of #23 — both can land in either order; the diff doesn't conflict.
- One concern: \`-u\` forces every Python child process to also be unbuffered. The speciesnet subprocess at [job.py:202](infra/inference/job.py:202) already passes \`-u\` explicitly, so no behavior change there.
- Verbose logs may grow slightly (each line is its own log entry rather than batched). Negligible cost at our volume.

## Test plan
- [ ] \`docker build\` succeeds and the entrypoint uses \`-u\`
- [ ] After deploy, a fresh inference run shows distinct (non-bunched) timestamps for each \`[running]\` line in Cloud Logging
- [ ] Subtracting markers gives plausible phase durations (e.g., upload-wait < 5 min, download depending on parallelization, speciesnet seconds-to-minutes, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)