### PR TITLE
Make SpeciesNet batch_size and run_mode env-configurable

### DIFF
--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -196,13 +196,26 @@ def main():
         with open(instances_file, "w") as f:
             json.dump({"instances": instances}, f)
 
-        set_status("running", "Running SpeciesNet inference…")
+        # SpeciesNet's classifier batch size and parallelism mode are tunable
+        # at the run_model.py CLI; expose them via env so deploys can sweep
+        # (gcloud run jobs update --update-env-vars) without rebuilding the
+        # image. Defaults match speciesnet's own defaults so omitting the
+        # env vars reproduces baseline behavior exactly.
+        speciesnet_batch_size = os.environ.get("SPECIESNET_BATCH_SIZE", "8")
+        speciesnet_run_mode   = os.environ.get("SPECIESNET_RUN_MODE", "multi_thread")
+        set_status(
+            "running",
+            f"Running SpeciesNet inference (batch_size={speciesnet_batch_size}, "
+            f"run_mode={speciesnet_run_mode})…",
+        )
 
         # ── Run SpeciesNet ────────────────────────────────────────────────────
         cmd = [
             "python", "-u", "-m", "speciesnet.scripts.run_model",
             "--instances_json", instances_file,
             "--predictions_json", predictions_file,
+            "--batch_size", speciesnet_batch_size,
+            "--run_mode", speciesnet_run_mode,
             "--bypass_prompts",
         ]
 


### PR DESCRIPTION
## Summary
- The `run_model.py` CLI accepts `--batch_size` (default 8) and `--run_mode` (default `multi_thread`); we weren't passing either, so we were silently taking speciesnet's defaults.
- Wire both through env vars: `SPECIESNET_BATCH_SIZE` and `SPECIESNET_RUN_MODE`. Defaults match speciesnet's own defaults so unset env vars reproduce baseline behavior exactly.
- The phase-start log line now records the chosen values so each Cloud Logging entry is self-describing.

## Context
PR #28 (resize-before-infer) showed CPU preprocess wasn't the bottleneck on the L4 — pre-resizing only saved ~4% on inference and added more cost than it saved. This PR opens the door to GPU-side tuning instead, without touching code between experiments.

## How to sweep
After this lands, swap values without rebuilding:
\`\`\`
gcloud run jobs update speciesnet-inference \
  --update-env-vars SPECIESNET_BATCH_SIZE=32,SPECIESNET_RUN_MODE=multi_thread
\`\`\`
Then re-run a representative batch and compare SpeciesNet phase duration in Cloud Logging.

## Suggested experiments
On the same ~232-image batch shape used for the baseline (n8cff: 89.6s / 0.421 s/img):

| BATCH_SIZE | RUN_MODE | Hypothesis |
|---|---|---|
| 16 | multi_thread | conservative bump, see if any GPU headroom |
| 32 | multi_thread | likely sweet spot for L4 (24 GB) on EfficientNetV2-M |
| 64 | multi_thread | push until OOM or no further gain |
| 32 | multi_process | separate processes per stage, may overlap better but pays per-image fork cost |

Stop at the first batch size that doesn't improve over the previous step or hits OOM.

## What this does NOT do
- No change to default behavior — env vars unset → identical to current main
- No change to GPU type, image, deploy script, or any other config
- No code path takes a different branch unless you set the env vars

## Test plan
- [ ] Deploy
- [ ] Baseline run with no env vars set — verify phase duration matches recent runs
- [ ] Set \`SPECIESNET_BATCH_SIZE=32\`, run same batch, capture duration from Cloud Logging
- [ ] If improvement, try \`64\`; if no improvement, stop
- [ ] If batch_size sweep helps, test \`SPECIESNET_RUN_MODE=multi_process\` at the best batch size
- [ ] Watch for CUDA OOM in logs at high batch sizes — fallback is dropping back to last known-good value

🤖 Generated with [Claude Code](https://claude.com/claude-code)