### PR TITLE
Mirror SpeciesNet output to stdout for Cloud Logging

### DIFF
--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -246,6 +246,13 @@ def main():
                 }
                 job_ref.update({"progress": progress, "updated_at": _now()})
             else:
+                # Mirror to stdout so Cloud Logging captures speciesnet's
+                # output (including stack traces and CUDA OOM messages).
+                # Without this, errors are only visible to the user via the
+                # in-app job-detail view, which makes post-mortems painful.
+                # Tqdm progress lines are intentionally skipped — they would
+                # add hundreds of lines per run with no diagnostic value.
+                print(f"[speciesnet] {line}", flush=True)
                 log.append(line)
                 job_ref.update({"message": line, "log": log[-50:], "updated_at": _now()})
 


### PR DESCRIPTION
## Summary
SpeciesNet's stdout (with stderr merged in via \`Popen(..., stderr=subprocess.STDOUT)\`) was being captured per-line and pushed only to Firestore as the job's \`log\` field. Errors and stack traces were therefore only visible to the user through the in-app job-detail view — Cloud Logging post-mortems showed only our own \`set_status\` lines plus the bare \"SpeciesNet exited with code N\" message.

Echo each non-tqdm line to stdout with \`flush=True\` so:
- Cloud Logging captures the actual error text (CUDA OOMs, stack traces, missing-file warnings, etc.)
- Lines land in Cloud Logging at emission time, not on process exit
- Tqdm progress bars are intentionally skipped (adding hundreds of progress lines to Cloud Logging per run would be noise without diagnostic value)

The Firestore log path is unchanged so the in-app view still works exactly as before.

## Why this matters
Last batch hit a real flag-parsing error from speciesnet that only surfaced as \"more details\" in the UI. Cloud Logging just had the \"exited with code 1\" line. Bumping the actual error to stdout makes it visible from \`gcloud logging read\` queries and Cloud Logging's UI without needing to open the per-job Firestore log.

## Test plan
- [x] Deploy
- [x] Run any batch — verify normal speciesnet startup lines (\`Loaded SpeciesNetDetector...\`, etc.) appear in Cloud Logging prefixed with \`[speciesnet]\`
- [x] Verify tqdm progress bars are NOT in Cloud Logging (they're handled separately as Firestore \`progress\` updates)
- [x] Optional: provoke an error (e.g. malformed env var) and verify the stack trace lands in Cloud Logging
- [x] Verify the in-app job-detail \"More details\" view still shows the same log lines as before (unchanged Firestore path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)