### PR TITLE
Bake SpeciesNet models at the path the Cloud Run job reads

### DIFF
--- a/infra/Dockerfile.inference
+++ b/infra/Dockerfile.inference
@@ -49,7 +49,13 @@ RUN python -m pip install --no-cache-dir -r requirements.txt \
 # already pays the image pull, so amortizing the model bytes there beats
 # downloading them from Kaggle Hub (or reading them through GCS FUSE) on
 # every job. See infra/inference/prefetch_models.py for what's fetched.
-ENV KAGGLEHUB_CACHE=/opt/kagglehub
+#
+# The path must match the KAGGLEHUB_CACHE env on the deployed Cloud Run
+# Job — historically /mnt/model-cache (originally a mounted volume that's
+# since been removed via --clear-volumes in the deploy script). When the
+# build path and the runtime env disagree, kagglehub silently re-fetches
+# the entire 250 MB bundle on every cold start.
+ENV KAGGLEHUB_CACHE=/mnt/model-cache
 COPY prefetch_models.py ./
 RUN python prefetch_models.py && rm prefetch_models.py
 

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -95,10 +95,11 @@ resource "google_cloud_run_v2_job" "inference" {
           name  = "GCP_PROJECT"
           value = var.project_id
         }
-        # KAGGLEHUB_CACHE env, the model-cache volume, and the volume mount
-        # are applied via the inference_gpu provisioner below — declaring
-        # them here would race with the gcloud update that re-asserts GPU
-        # config and wipe v2-only fields.
+        # KAGGLEHUB_CACHE is baked into the inference image (see
+        # ENV in Dockerfile.inference) so model files prefetched at build
+        # time are found at runtime. Declaring it here would race with the
+        # gcloud update below that re-asserts GPU config and could wipe
+        # v2-only fields.
       }
     }
   }


### PR DESCRIPTION
## Summary
The Dockerfile prefetches kagglehub models with \`KAGGLEHUB_CACHE=/opt/kagglehub\`, but the deployed Cloud Run Job has \`KAGGLEHUB_CACHE=/mnt/model-cache\` (leftover from when there was a mounted volume that's since been \`--clear-volumes\`'d out). At runtime, speciesnet looks in \`/mnt/model-cache\`, finds nothing, and silently re-downloads the model bundle on every cold start.

The Cloud Logging fix (PR #31) made this visible:

\`\`\`
19:09:22  [speciesnet] Downloading to /mnt/model-cache/...labels.20251208.txt...
19:09:22  [speciesnet] Downloading to /mnt/model-cache/...info.json...
19:09:23  [speciesnet]  10%|? | 22.0M/214M [00:00<00:01, 121MB/s]
...
19:09:25  [speciesnet] 100%|??????????| 214M/214M [00:02<00:00, 89.4MB/s]
\`\`\`

214 MB classifier weights + ~250 KB taxonomy + a handful of other files re-downloaded every time the container cold-starts. Costs **~3–5 s** of cold-start latency plus the kagglehub bandwidth, on every job that doesn't hit a warm container.

## Fix
- Set \`ENV KAGGLEHUB_CACHE=/mnt/model-cache\` in the Dockerfile so the prefetch lands at the path the runtime expects. One-line change with a comment explaining why we use \`/mnt/...\` instead of the more conventional \`/opt/...\`.
- Update the (misleading) comment in \`cloudrun.tf\` that claimed the env was set by the GPU provisioner — it's actually baked into the image, and now the comment says so.

## Test plan
- [ ] Build + push the inference image with this change
- [ ] Run a cold-start batch
- [ ] Verify the new \`[speciesnet]\` Cloud Logging output does NOT contain any \"Downloading to /mnt/model-cache/...\" lines (just the existing \"Loaded SpeciesNetClassifier\" / \"Loaded SpeciesNetDetector\" log lines)
- [ ] Verify the SpeciesNet phase starts ~3 s sooner than recent runs (the 31s \"phase fixed cost\" we modeled earlier should drop to ~26-28s)

## What this does NOT change
- Runtime env on the Cloud Run Job (already \`/mnt/model-cache\` — no gcloud action needed)
- The deploy script
- Anything user-visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)