### PR TITLE
Pipeline upload-wait and download into one phase

### DIFF
--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 import tempfile
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -41,8 +41,11 @@ CROP_WORKERS = 16
 
 # The web backend fires run_job at upload-prepare time, so the container
 # often starts cold-starting BEFORE the browser has finished PUT-ing all
-# files to GCS. Poll for missing blobs here, up to a generous timeout, so
-# the cold-start overlaps with (instead of following) the upload phase.
+# files to GCS. Each download worker polls for its assigned blob, then
+# downloads as soon as it appears — pipelining the wait and the download
+# so by the time the last upload arrives, earlier files are already on
+# disk. The timeout below is per-file, not per-job: a single file that
+# never arrives fails the job after this much wall time.
 UPLOAD_WAIT_TIMEOUT_S = 900   # 15 min — well above any realistic upload
 UPLOAD_WAIT_POLL_S    = 3
 
@@ -151,37 +154,49 @@ def main():
     latitude      = params.get("latitude")
     longitude     = params.get("longitude")
 
-    # ── Wait for any uploads that are still in flight ─────────────────────
-    # The backend may have kicked off run_job before the browser finished
-    # PUT-ing files. Block here until all blobs exist, or fail after a
-    # generous timeout.
-    _wait_for_uploads(bucket, files, set_status)
-
-    set_status("running", f"Downloading {len(files)} image(s) from storage…")
+    set_status("running", f"Fetching {len(files)} image(s) from storage…")
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # ── Download images from GCS ──────────────────────────────────────────
-        # Sequential downloads were the dominant cost on large batches:
-        # GCS round-trip latency (~50-200ms) stacked across 500 blobs is
-        # several minutes. Parallelize so wall time scales by total bytes
-        # rather than blob count.
+        # ── Wait + download in a single pipelined phase ───────────────────
+        # The backend often fires run_job before the browser has finished
+        # PUT-ing every file. Previously we waited for every blob to exist
+        # and only then started parallel downloads — that left ~10s of
+        # serialized download work running AFTER the last upload landed.
+        # Now each worker polls for its assigned blob and downloads as
+        # soon as it appears, so by the time the last upload arrives the
+        # earlier files are already on disk. For already-uploaded jobs
+        # each worker probes once and proceeds straight to download
+        # (one HEAD per file vs the old N-HEADs-per-poll-cycle approach).
         local_paths: list[str] = []
         path_map: dict[str, str] = {}  # local_path -> gcs_path
 
-        def _download_one(gcs_path: str) -> tuple[str, str]:
-            filename   = Path(gcs_path).name
-            local_path = os.path.join(tmpdir, filename)
-            bucket.blob(gcs_path).download_to_filename(local_path)
+        def _wait_and_download_one(gcs_path: str) -> tuple[str, str]:
+            blob = bucket.blob(gcs_path)
+            start = time.time()
+            while not blob.exists():
+                if time.time() - start > UPLOAD_WAIT_TIMEOUT_S:
+                    raise TimeoutError(
+                        f"Upload never arrived after {UPLOAD_WAIT_TIMEOUT_S}s: {gcs_path}"
+                    )
+                time.sleep(UPLOAD_WAIT_POLL_S)
+            local_path = os.path.join(tmpdir, Path(gcs_path).name)
+            blob.download_to_filename(local_path)
             return gcs_path, local_path
 
         with ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as ex:
+            futures = [ex.submit(_wait_and_download_one, f) for f in files]
             done = 0
-            for gcs_path, local_path in ex.map(_download_one, files):
-                local_paths.append(local_path)
-                path_map[local_path] = gcs_path
-                done += 1
-                if done % 20 == 0 or done == len(files):
-                    set_status("running", f"Downloaded {done}/{len(files)} images…")
+            try:
+                for fut in as_completed(futures):
+                    gcs_path, local_path = fut.result()
+                    local_paths.append(local_path)
+                    path_map[local_path] = gcs_path
+                    done += 1
+                    if done % 20 == 0 or done == len(files):
+                        set_status("running", f"Fetched {done}/{len(files)} images…")
+            except TimeoutError as exc:
+                set_status("error", str(exc))
+                raise SystemExit(1)
 
         # ── Build instances JSON ──────────────────────────────────────────────
         instances = []
@@ -434,36 +449,6 @@ def main():
         set_status("done", f"Done — {count} prediction(s) saved",
                    {"completed_at": now, "summary": summary})
         print(f"[done] Saved {count} predictions for user {uid}")
-
-
-def _wait_for_uploads(bucket, files: list[str], set_status) -> None:
-    """Poll GCS until every path in `files` has an object, or time out.
-
-    First pass: if everything's already uploaded we don't touch the job
-    doc at all, so fully-uploaded-then-process flows behave identically
-    to before. Only prints a "Waiting for uploads…" status when we
-    actually need to wait.
-    """
-    missing = [p for p in files if not bucket.blob(p).exists()]
-    if not missing:
-        return
-
-    start = time.time()
-    while missing:
-        present = len(files) - len(missing)
-        set_status(
-            "running",
-            f"Waiting for uploads ({present}/{len(files)} ready)…",
-        )
-        if time.time() - start > UPLOAD_WAIT_TIMEOUT_S:
-            set_status(
-                "error",
-                f"Timed out waiting for uploads — {len(missing)}/{len(files)} "
-                f"file(s) never arrived in GCS",
-            )
-            raise SystemExit(1)
-        time.sleep(UPLOAD_WAIT_POLL_S)
-        missing = [p for p in files if not bucket.blob(p).exists()]
 
 
 def _now() -> str:


### PR DESCRIPTION
## Summary
The container previously waited for *every* upload to land in GCS before starting parallel downloads. Recent runs (e.g. \`wbm6s\`) spent ~60 s polling, then another ~15 s downloading after the last upload arrived — the post-wait download phase was pure serialized work that could've overlapped with the wait.

Replace \`_wait_for_uploads\` + the separate download loop with a single per-file worker: each thread polls for *its* assigned blob, then downloads as soon as it appears. By the time the last upload arrives, the earlier files are already on disk.

## Mechanics
- New \`_wait_and_download_one\` worker handles its own probe-loop, then downloads inline.
- 16-way \`ThreadPoolExecutor\` (same \`DOWNLOAD_WORKERS\` constant as before).
- Switched from \`ex.map\` to \`as_completed\` — progress reports as files actually finish instead of in input order. Side benefit: fixes the existing quirk where one slow file would freeze the \"Downloaded X/Y\" line from advancing past it (visible in baseline \`n8cff\` logs).
- Per-file timeout \`UPLOAD_WAIT_TIMEOUT_S\` (15 min). A single missing file fails the job after that — same effective behavior as before, just measured per-file.

## Already-uploaded jobs
- Each worker probes its blob once (1 HEAD per file).
- Old behavior was 1 bulk HEAD pass + (potentially) repeated N-HEADs-per-3s polls.
- Net HEAD load drops in the wait case too (~5 HEADs/sec across 16 workers vs ~50 HEADs every 3s in the bulk loop).
- No additional latency — fast path is identical wall time.

## Estimated impact on recent runs

| Run | Imgs | Old wait | Old download | Old total fetch | Estimated new fetch | Saved |
|---|---:|---:|---:|---:|---:|---:|
| \`wbm6s\` | 234 | 60 s | 15 s | 75 s | ~62 s | **~13 s** |
| \`gtnbm\` | 215 | 29 s | 12 s | 41 s | ~30 s | **~11 s** |
| \`q89b4\` | 160 | 26 s | 9 s | 35 s | ~26 s | **~9 s** |
| Already-uploaded job | — | 0 s | ~10 s | ~10 s | ~10 s | 0 |

## What this does NOT change
- \`DOWNLOAD_WORKERS = 16\` — unchanged
- Per-file timeout \`UPLOAD_WAIT_TIMEOUT_S = 900s\` — unchanged
- Anything downstream (instances.json, speciesnet, crop gen) — untouched
- \`path_map\` semantics — unchanged

## Test plan
- [x] Deploy
- [x] Run a batch where uploads are still in flight (kick run_job before browser PUTs all files) — verify \"Fetched X/Y\" status updates flow smoothly during the wait window
- [x] Run a batch where all files are already in GCS — verify total fetch time matches recent already-uploaded runs (no regression)
- [x] Provoke a missing-file scenario (delete one blob right before run_job) — verify the \"Upload never arrived after 900s\" error fires for that single file
- [x] Compare phase-time logs on a wbm6s-shape job vs the baseline numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)