### PR TITLE
Stream predictions to Firestore as inference produces them

### DIFF
--- a/infra/Dockerfile.inference
+++ b/infra/Dockerfile.inference
@@ -45,6 +45,19 @@ RUN python -m pip install --no-cache-dir -r requirements.txt \
     && find "$SITE" -type d -name 'tests' -prune -exec rm -rf {} + \
     && find "$SITE" -name '*.pyc' -delete
 
+# Patch SpeciesNet's hardcoded periodic-save interval from 600s to 5s so
+# job.py can stream predictions to Firestore as inference proceeds (the
+# upload dialog renders thumbnails of newly-classified animals in near-
+# real-time). The interval is hardcoded inline at the only call site so
+# no upstream config knob exists; sed it here, then verify the patch
+# took effect — fail the build if speciesnet's source changed and our
+# match no longer applies, so silent breakage is impossible.
+RUN SN_DIR=$(python -c "import speciesnet, os; print(os.path.dirname(speciesnet.__file__))") \
+    && sed -i 's|interval=600,  # 10 minutes\.|interval=5,  # streaming patch — was 10 minutes|' \
+        "$SN_DIR/multiprocessing.py" \
+    && grep -q 'interval=5,  # streaming patch' "$SN_DIR/multiprocessing.py" \
+        || (echo "ERROR: speciesnet streaming patch did not apply — check the sed pattern" && exit 1)
+
 # Bake the SpeciesNet model into the image. Each cold-started container
 # already pays the image pull, so amortizing the model bytes there beats
 # downloading them from Kaggle Hub (or reading them through GCS FUSE) on

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -373,13 +373,31 @@ def main():
                     f"Streamed predictions: {my_count}/{len(files)} processed…",
                 )
 
-        def _scan_predictions_file(pool: ThreadPoolExecutor) -> None:
+        def _scan_predictions_file(
+            pool: ThreadPoolExecutor, accept_failures: bool = False
+        ) -> None:
             """Read predictions.json, dispatch new entries to workers.
             Idempotent — tracks `processed_filepaths` so each prediction
             runs exactly once even though we re-read the whole file each
             cycle. Speciesnet's atomic temp-file-then-rename means we
             never see partial writes; a JSONDecodeError just retries on
-            the next cycle."""
+            the next cycle.
+
+            CRITICAL: speciesnet's `_merge_results` writes a stub
+            `{filepath, failures: [...]}` entry for *every* input filepath
+            whose pipeline hasn't completed yet — see
+            github.com/google/cameratrapai/blob/main/speciesnet/multiprocessing.py:458.
+            So a periodic save at t=5s with only 10 of 119 predictions
+            done contains 10 real entries plus 109 failure stubs. If we
+            naively process those stubs we mark all 119 filepaths as
+            done and miss the real predictions when they arrive in later
+            saves — which is what produced the "lots of animals labelled
+            blank" regression in execution g7jrp.
+
+            Skip failure entries during in-progress scans so a stub
+            doesn't claim a filepath; pick them up in the final scan
+            after speciesnet exits, where any remaining failures are
+            real (e.g. an unloadable JPEG)."""
             if not os.path.exists(predictions_file):
                 return
             try:
@@ -391,9 +409,12 @@ def main():
             with processed_lock:
                 for pred in data.get("predictions", []):
                     fp = pred.get("filepath")
-                    if fp and fp not in processed_filepaths:
-                        processed_filepaths.add(fp)
-                        new_preds.append(pred)
+                    if not fp or fp in processed_filepaths:
+                        continue
+                    if pred.get("failures") and not accept_failures:
+                        continue
+                    processed_filepaths.add(fp)
+                    new_preds.append(pred)
             for pred in new_preds:
                 pool.submit(_process_one_prediction, pred)
 
@@ -438,10 +459,12 @@ def main():
 
         def _watcher() -> None:
             while not stop_event.wait(timeout=PREDICTIONS_POLL_S):
-                _scan_predictions_file(worker_pool)
-            # Final scan once speciesnet exits — picks up the last
-            # periodic save plus the final atomic write.
-            _scan_predictions_file(worker_pool)
+                _scan_predictions_file(worker_pool, accept_failures=False)
+            # Final scan once speciesnet exits — accept failure entries
+            # at this point because they're now genuine (load_rgb_image
+            # gave up on a corrupt file etc.) rather than "not yet
+            # processed" stubs from an in-flight pipeline.
+            _scan_predictions_file(worker_pool, accept_failures=True)
 
         watcher_thread = threading.Thread(target=_watcher, daemon=True)
         watcher_thread.start()

--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import tempfile
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -36,8 +37,19 @@ UPLOAD_WORKERS   = 16
 # per source image. PIL's libjpeg / libpng C calls release the GIL, so
 # threads do give real parallelism here. A single-threaded loop on a
 # 200-image / 200-crop batch was running ~30s; pooling matches the
-# download/upload pattern above.
+# download/upload pattern above. The same pool also handles the per-
+# prediction crop+upload+firestore work in streaming mode (see below).
 CROP_WORKERS = 16
+
+# Streaming mode: the inference image patches speciesnet's hardcoded
+# 600s "save partial results" interval down to 5s (see Dockerfile.inference).
+# That means predictions.json gets atomically rewritten ~every 5s during
+# inference. We poll it on a slightly faster cadence so a save we missed
+# at 5.1s lands within ~2s, and dispatch newly-arrived predictions to a
+# worker pool for crop+upload+firestore — so the upload dialog can show
+# thumbnails as classifications complete instead of waiting for the
+# whole inference run.
+PREDICTIONS_POLL_S = 2
 
 # The web backend fires run_job at upload-prepare time, so the container
 # often starts cold-starting BEFORE the browser has finished PUT-ing all
@@ -218,11 +230,177 @@ def main():
         with open(instances_file, "w") as f:
             json.dump({"instances": instances}, f)
 
+        folder = job_doc.get("folder", "")
+        log: list[str] = []
+        progress: dict = {}
+
+        # ── Streaming-prediction state ────────────────────────────────────
+        # Workers running in `worker_pool` consume new predictions as
+        # speciesnet writes them and produce: (a) crop file + GCS upload,
+        # (b) a per-prediction Firestore doc with crop_gcs_path filled in,
+        # and (c) summary aggregates. The watcher thread polls
+        # predictions.json every PREDICTIONS_POLL_S seconds and dispatches
+        # any prediction whose filepath we haven't seen yet.
+        processed_filepaths: set[str] = set()
+        processed_lock = threading.Lock()
+        summary_lock   = threading.Lock()
+        by_species:     dict[str, int] = {}
+        by_category:    dict[str, int] = {}
+        summary_images: list[dict] = []
+        count_lock = threading.Lock()
+        count = 0
+
+        def _generate_crops_for_pred(pred: dict) -> list[tuple[str, str, dict]]:
+            """Open the source image once, emit one crop file per qualifying
+            detection. Avoids re-decoding the same JPEG per detection."""
+            local_fp = pred["filepath"]
+            gcs_path = path_map.get(local_fp, local_fp)
+            filename = Path(gcs_path).name
+            valid = [
+                (idx, det) for idx, det in enumerate(pred.get("detections", []))
+                if det.get("conf", 0) >= CROP_CONF_THRESHOLD and det.get("bbox")
+            ]
+            if not valid:
+                return []
+            try:
+                # Apply EXIF orientation so portrait-mode photos crop
+                # in the orientation the browser displays them in.
+                with Image.open(local_fp) as raw:
+                    source_image = ImageOps.exif_transpose(raw)
+            except Exception as exc:
+                log.append(f"crop: could not open {local_fp}: {exc}")
+                return []
+            results: list[tuple[str, str, dict]] = []
+            try:
+                stem = Path(filename).stem
+                for idx, det in valid:
+                    crop_filename = f"{stem}_detection_{idx + 1}.jpg"
+                    crop_local = os.path.join(tmpdir, crop_filename)
+                    try:
+                        _save_crop(source_image, det["bbox"], crop_local)
+                    except Exception as exc:
+                        log.append(f"crop: failed for {filename} det {idx}: {exc}")
+                        continue
+                    crop_gcs_path = f"crops/{uid}/{folder}/{crop_filename}"
+                    results.append((crop_local, crop_gcs_path, det))
+            finally:
+                source_image.close()
+            return results
+
+        def _process_one_prediction(pred: dict) -> None:
+            """End-to-end work for a single prediction: crops, uploads,
+            Firestore doc, summary. Called from worker_pool."""
+            nonlocal count
+            local_fp = pred["filepath"]
+            gcs_path = path_map.get(local_fp, local_fp)
+            filename = Path(gcs_path).name
+
+            # Crops + uploads. Each crop is independent; failures log and
+            # continue rather than failing the whole prediction.
+            for local, remote, det in _generate_crops_for_pred(pred):
+                try:
+                    bucket.blob(remote).upload_from_filename(
+                        local, content_type="image/jpeg"
+                    )
+                    det["crop_gcs_path"] = remote
+                except Exception as exc:
+                    log.append(f"upload: failed for {remote}: {exc}")
+
+            prediction_label = None
+            if "prediction" in pred:
+                prediction_label = _parse_label(pred["prediction"])
+
+            top5 = []
+            if "classifications" in pred:
+                for cls, score in zip(
+                    pred["classifications"]["classes"],
+                    pred["classifications"]["scores"],
+                ):
+                    top5.append({**_parse_label(cls), "score": round(score, 4)})
+
+            now_iso = _now()
+            doc = {
+                "gcs_path":          gcs_path,
+                "filename":          filename,
+                "folder":            folder,
+                "uid":               uid,
+                "taken_at":          _extract_taken_at(local_fp),
+                "prediction":        prediction_label,
+                "prediction_score":  pred.get("prediction_score"),
+                "prediction_source": pred.get("prediction_source"),
+                "top5":              top5,
+                "detections":        pred.get("detections", []),
+                "model_version":     pred.get("model_version"),
+                "failures":          pred.get("failures", []),
+                "country":           pred.get("country"),
+                "latitude":          pred.get("latitude"),
+                "longitude":         pred.get("longitude"),
+                "job_id":            job_id,
+                "created_at":        now_iso,
+                "updated_at":        now_iso,
+            }
+            doc_id = hashlib.md5(gcs_path.encode()).hexdigest()
+            # Per-doc set instead of batched commit: each one needs to land
+            # in Firestore as soon as it's ready so the upload-dialog UI
+            # can render the thumbnail. ~3 writes/sec is well under the
+            # per-collection write-rate guideline.
+            pred_col.document(doc_id).set(doc, merge=True)
+
+            common = prediction_label["common_name"] if prediction_label else None
+            category = None
+            if common:
+                low = common.lower()
+                category = low if low in {"blank", "human", "vehicle"} else "animal"
+
+            with summary_lock:
+                if common:
+                    by_species[common] = by_species.get(common, 0) + 1
+                    by_category[category] = by_category.get(category, 0) + 1
+                summary_images.append({
+                    "filename":    filename,
+                    "common_name": common,
+                    "score":       round(pred.get("prediction_score") or 0, 3),
+                    "category":    category,
+                })
+
+            with count_lock:
+                count += 1
+                my_count = count
+
+            if my_count % 20 == 0 or my_count == len(files):
+                set_status(
+                    "running",
+                    f"Streamed predictions: {my_count}/{len(files)} processed…",
+                )
+
+        def _scan_predictions_file(pool: ThreadPoolExecutor) -> None:
+            """Read predictions.json, dispatch new entries to workers.
+            Idempotent — tracks `processed_filepaths` so each prediction
+            runs exactly once even though we re-read the whole file each
+            cycle. Speciesnet's atomic temp-file-then-rename means we
+            never see partial writes; a JSONDecodeError just retries on
+            the next cycle."""
+            if not os.path.exists(predictions_file):
+                return
+            try:
+                with open(predictions_file, encoding="utf-8") as f:
+                    data = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                return
+            new_preds = []
+            with processed_lock:
+                for pred in data.get("predictions", []):
+                    fp = pred.get("filepath")
+                    if fp and fp not in processed_filepaths:
+                        processed_filepaths.add(fp)
+                        new_preds.append(pred)
+            for pred in new_preds:
+                pool.submit(_process_one_prediction, pred)
+
         # SpeciesNet's classifier batch size and parallelism mode are tunable
         # at the run_model.py CLI; expose them via env so deploys can sweep
         # (gcloud run jobs update --update-env-vars) without rebuilding the
-        # image. Defaults match speciesnet's own defaults so omitting the
-        # env vars reproduces baseline behavior exactly.
+        # image.
         speciesnet_batch_size = os.environ.get("SPECIESNET_BATCH_SIZE", "8")
         speciesnet_run_mode   = os.environ.get("SPECIESNET_RUN_MODE", "multi_thread")
         set_status(
@@ -251,8 +429,22 @@ def main():
             bufsize=1,
         )
 
-        log: list[str] = []
-        progress: dict = {}
+        # Start the predictions-file watcher and the per-prediction worker
+        # pool BEFORE consuming the speciesnet stdout — speciesnet emits
+        # its first periodic save ~5s after starting, and we want the
+        # watcher live by then.
+        worker_pool = ThreadPoolExecutor(max_workers=CROP_WORKERS)
+        stop_event = threading.Event()
+
+        def _watcher() -> None:
+            while not stop_event.wait(timeout=PREDICTIONS_POLL_S):
+                _scan_predictions_file(worker_pool)
+            # Final scan once speciesnet exits — picks up the last
+            # periodic save plus the final atomic write.
+            _scan_predictions_file(worker_pool)
+
+        watcher_thread = threading.Thread(target=_watcher, daemon=True)
+        watcher_thread.start()
 
         for line in process.stdout:
             line = _ANSI_ESCAPE.sub("", line).rstrip()
@@ -270,8 +462,6 @@ def main():
             else:
                 # Mirror to stdout so Cloud Logging captures speciesnet's
                 # output (including stack traces and CUDA OOM messages).
-                # Without this, errors are only visible to the user via the
-                # in-app job-detail view, which makes post-mortems painful.
                 # Tqdm progress lines are intentionally skipped — they would
                 # add hundreds of lines per run with no diagnostic value.
                 print(f"[speciesnet] {line}", flush=True)
@@ -282,162 +472,16 @@ def main():
 
         if process.returncode != 0:
             set_status("error", f"SpeciesNet exited with code {process.returncode}")
+            stop_event.set()
+            worker_pool.shutdown(wait=False, cancel_futures=True)
             raise SystemExit(1)
 
-        # Marker so phase timing in Cloud Logging shows speciesnet end ≠
-        # crop/firestore work (the existing set_status calls already mark
-        # the start of each downstream phase).
-        set_status("running", "SpeciesNet complete — building crops…")
-        with open(predictions_file, encoding="utf-8") as f:
-            output = json.load(f)
-
-        folder = job_doc.get("folder", "")
-
-        # ── Generate crops (CPU, parallel) then upload (I/O, parallel) ────
-        # PIL decode + crop + JPEG encode is the dominant non-inference
-        # cost on detection-heavy batches (~30s for 200 crops on a 200-
-        # image batch, single-threaded). libjpeg releases the GIL so a
-        # thread pool gives near-linear speedup; we still serialize per-
-        # image work (open the source once, emit all its crops together)
-        # to avoid re-decoding the same JPEG once per detection.
-        def _generate_crops_for_pred(pred: dict) -> list[tuple[str, str, dict]]:
-            local_fp = pred["filepath"]
-            gcs_path = path_map.get(local_fp, local_fp)
-            filename = Path(gcs_path).name
-            valid = [
-                (idx, det) for idx, det in enumerate(pred.get("detections", []))
-                if det.get("conf", 0) >= CROP_CONF_THRESHOLD and det.get("bbox")
-            ]
-            if not valid:
-                return []
-            try:
-                # Apply EXIF orientation so portrait-mode photos crop
-                # in the orientation the browser displays them in.
-                # Without this, crops come out 90°/180° rotated for
-                # any image whose camera embedded a non-default
-                # Orientation tag (very common on trail cams).
-                with Image.open(local_fp) as raw:
-                    source_image = ImageOps.exif_transpose(raw)
-            except Exception as exc:
-                log.append(f"crop: could not open {local_fp}: {exc}")
-                return []
-            results: list[tuple[str, str, dict]] = []
-            try:
-                stem = Path(filename).stem
-                for idx, det in valid:
-                    crop_filename = f"{stem}_detection_{idx + 1}.jpg"
-                    crop_local = os.path.join(tmpdir, crop_filename)
-                    try:
-                        _save_crop(source_image, det["bbox"], crop_local)
-                    except Exception as exc:
-                        log.append(f"crop: failed for {filename} det {idx}: {exc}")
-                        continue
-                    crop_gcs_path = f"crops/{uid}/{folder}/{crop_filename}"
-                    results.append((crop_local, crop_gcs_path, det))
-            finally:
-                source_image.close()
-            return results
-
-        crop_jobs: list[tuple[str, str, dict]] = []  # (local_path, gcs_path, det)
-        with ThreadPoolExecutor(max_workers=CROP_WORKERS) as ex:
-            for crop_entries in ex.map(_generate_crops_for_pred, output.get("predictions", [])):
-                crop_jobs.extend(crop_entries)
-
-        if crop_jobs:
-            set_status("running", f"Uploading {len(crop_jobs)} crop(s)…")
-
-            def _upload_crop(job: tuple[str, str, dict]) -> None:
-                local, remote, det = job
-                bucket.blob(remote).upload_from_filename(local, content_type="image/jpeg")
-                det["crop_gcs_path"] = remote
-
-            with ThreadPoolExecutor(max_workers=UPLOAD_WORKERS) as ex:
-                for _ in ex.map(_upload_crop, crop_jobs):
-                    pass
-
-        # ── Write predictions to Firestore ────────────────────────────────────
-        set_status("running", "Saving predictions to database…")
-
-        batch = db.batch()
-        batch_count = 0
-        count = 0
-        now = _now()
-
-        # Summary data shown in the upload dialog when the job completes.
-        # Category names mirror the gallery badges (animal/human/vehicle/blank).
-        by_species:  dict[str, int] = {}
-        by_category: dict[str, int] = {}
-        summary_images: list[dict] = []
-
-        for pred in output.get("predictions", []):
-            local_fp = pred["filepath"]
-            gcs_path = path_map.get(local_fp, local_fp)
-            filename = Path(gcs_path).name
-
-            doc_id = hashlib.md5(gcs_path.encode()).hexdigest()
-
-            prediction_label = None
-            if "prediction" in pred:
-                prediction_label = _parse_label(pred["prediction"])
-
-            top5 = []
-            if "classifications" in pred:
-                for cls, score in zip(
-                    pred["classifications"]["classes"],
-                    pred["classifications"]["scores"],
-                ):
-                    top5.append({**_parse_label(cls), "score": round(score, 4)})
-
-            detections = pred.get("detections", [])
-
-            doc = {
-                "gcs_path":          gcs_path,
-                "filename":          filename,
-                "folder":            folder,
-                "uid":               uid,
-                "taken_at":          _extract_taken_at(local_fp),
-                "prediction":        prediction_label,
-                "prediction_score":  pred.get("prediction_score"),
-                "prediction_source": pred.get("prediction_source"),
-                "top5":              top5,
-                "detections":        detections,
-                "model_version":     pred.get("model_version"),
-                "failures":          pred.get("failures", []),
-                "country":           pred.get("country"),
-                "latitude":          pred.get("latitude"),
-                "longitude":         pred.get("longitude"),
-                "job_id":            job_id,
-                "created_at":        now,
-                "updated_at":        now,
-            }
-
-            batch.set(pred_col.document(doc_id), doc, merge=True)
-            batch_count += 1
-            count += 1
-
-            # ── Accumulate summary data ───────────────────────────────
-            common = prediction_label["common_name"] if prediction_label else None
-            if common:
-                low = common.lower()
-                category = low if low in {"blank", "human", "vehicle"} else "animal"
-                by_species[common] = by_species.get(common, 0) + 1
-                by_category[category] = by_category.get(category, 0) + 1
-            else:
-                category = None
-            summary_images.append({
-                "filename":    filename,
-                "common_name": common,
-                "score":       round(pred.get("prediction_score") or 0, 3),
-                "category":    category,
-            })
-
-            if batch_count >= 400:   # Firestore batch limit is 500
-                batch.commit()
-                batch = db.batch()
-                batch_count = 0
-
-        if batch_count > 0:
-            batch.commit()
+        # Speciesnet is done. Tell the watcher to do its final scan and
+        # exit, then wait for any in-flight per-prediction workers to
+        # land their crops + Firestore docs.
+        stop_event.set()
+        watcher_thread.join()
+        worker_pool.shutdown(wait=True)
 
         summary = {
             "total":        count,
@@ -447,7 +491,7 @@ def main():
         }
 
         set_status("done", f"Done — {count} prediction(s) saved",
-                   {"completed_at": now, "summary": summary})
+                   {"completed_at": _now(), "summary": summary})
         print(f"[done] Saved {count} predictions for user {uid}")
 
 


### PR DESCRIPTION
## Summary
Replaces the post-inference batch crop/upload/firestore phases with streaming: SpeciesNet's predictions.json is polled while inference runs, and each newly-classified image gets crop generation, GCS upload, and a Firestore doc independently. Upload-dialog UI can subscribe and render thumbnails as classifications complete instead of waiting 4–5 min for the whole batch to finish.

## Mechanics

### Dockerfile patch (interval 600 → 5)
SpeciesNet's `_start_periodic_results_saving` is hardcoded with \`interval=600\` (10 min). For typical 3-minute jobs the periodic saver never fires; only the final atomic write at the end of inference produces predictions.json. Patch the literal in the installed package via \`sed\` at image-build time, then \`grep\` to verify the patch took effect — if SpeciesNet's source changes and the pattern no longer matches, the build fails immediately rather than silently degrading to 600s polling at runtime.

### job.py refactor
- New \`_process_one_prediction(pred)\` runs the full per-image pipeline (crops + uploads + Firestore + summary aggregation) for a single prediction. The summary aggregates (\`by_species\`, \`by_category\`, \`summary_images\`) live under a lock since workers update concurrently.
- New \`_scan_predictions_file(pool)\` reads predictions.json and dispatches any newly-arrived prediction to the worker pool. Idempotent via a \`processed_filepaths\` set so each prediction runs exactly once even though the watcher re-reads the whole file every cycle.
- New \`_watcher\` thread polls every \`PREDICTIONS_POLL_S\` (2 s) while inference runs, then does one final scan after subprocess exit to catch the final atomic write.
- \`pred_col.document(doc_id).set(doc, merge=True)\` is now called per-prediction directly (no batching). At ~3 writes/sec on long jobs that's well under the per-collection write-rate guidelines, and the latency benefit is the whole point of this PR.
- The post-subprocess crop, upload, and Firestore-batch loops are removed — their work now happens in the per-prediction worker.

### Backend behavior preserved
- All crops still generated (CROP_CONF_THRESHOLD=0.2 unchanged) and uploaded to GCS with the same naming scheme.
- Every prediction still gets a Firestore doc with the same field set.
- Summary still has total / by_species / by_category / images.
- Failures (crop open errors, GCS upload errors) still log to the per-job \`log\` field.

### UI side (separate, not in this PR)
The upload-dialog UI just needs a Firestore subscription with a filter:
\`\`\`
predictions
  .where('job_id', '==', currentJobId)
  .where('prediction_score', '>=', 0.5)
\`\`\`
…and client-side, ignore docs where \`category\` is \`blank\`/\`human\`/\`vehicle\` or where \`detections[].crop_gcs_path\` is missing. The most-recent qualifying doc populates the thumbnail panel.

## Concurrency notes
- Watcher thread → \`processed_filepaths\` set, guarded by \`processed_lock\`.
- Worker threads → \`by_species\` / \`by_category\` / \`summary_images\` / \`count\`, guarded by their respective locks.
- Watcher dispatches to the worker pool. Main thread reads SpeciesNet stdout (unchanged).
- On subprocess exit (success): \`stop_event.set()\` → watcher does final scan and exits → \`worker_pool.shutdown(wait=True)\` waits for in-flight workers → final summary write.
- On subprocess exit (error): \`stop_event.set()\` + \`worker_pool.shutdown(wait=False, cancel_futures=True)\` so the container can die fast rather than waiting on per-prediction workers.

## What this does NOT change
- SpeciesNet command line (still passes batch_size and run_mode env vars)
- Crop dimensions / JPEG quality
- The Cloud Run job spec / GPU config / image size

## Test plan
- [x] Build the new image and verify the Dockerfile sed patch lands (\`grep 'interval=5' /usr/local/lib/python3.11/site-packages/speciesnet/multiprocessing.py\` from inside the container)
- [x] Run a representative batch (~150-200 images with non-trivial detection density)
- [x] Verify Firestore predictions appear during inference (subscribe to a test query and watch docs land)
- [x] Verify total job time is roughly the SpeciesNet phase time (since crop work overlaps with inference now)
- [x] Verify summary at end of job has the same totals as before
- [x] Provoke a SpeciesNet failure (e.g. malformed instance) and verify the error path exits cleanly without hanging on workers

## Expected wall-clock impact
On the \`zfjdf\` shape (870 imgs, 867 crops): SpeciesNet was 261 s, crop-gen+upload+firestore was ~53 s — those phases ran sequentially before. With streaming, the 53 s of post-work overlaps inside the 261 s SpeciesNet window. Net: ~50 s saved on detection-heavy jobs. Light-detection jobs save proportionally less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)