### PR TITLE
Stream a 'latest classification' thumbnail in the upload dialog

### DIFF
--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -363,6 +363,32 @@ def main():
                     "category":    category,
                 })
 
+            # Surface a "latest qualifying crop" pointer on the job doc so
+            # the upload-dialog UI can render a live thumbnail of the most-
+            # recently-classified animal without subscribing to Firestore
+            # or running a separate query (the doc is already polled every
+            # 2s for status). Concurrent updates from multiple workers are
+            # last-writer-wins, which is exactly the desired semantics:
+            # whichever prediction completed most recently wins the slot.
+            score = pred.get("prediction_score") or 0
+            if category == "animal" and score >= 0.5:
+                best_crop = max(
+                    (d for d in pred.get("detections", []) if d.get("crop_gcs_path")),
+                    key=lambda d: d.get("conf", 0),
+                    default=None,
+                )
+                if best_crop:
+                    job_ref.update({
+                        "latest_animal_crop": {
+                            "filename":      filename,
+                            "common_name":   common,
+                            "score":         round(score, 3),
+                            "crop_gcs_path": best_crop["crop_gcs_path"],
+                            "classified_at": now_iso,
+                        },
+                        "updated_at": now_iso,
+                    })
+
             with count_lock:
                 count += 1
                 my_count = count

--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -135,6 +135,11 @@
         </div>
       </div>
     </div>
+    <footer style="width: 100%"><label>TrailCam Viewer Copyright &copy 2026</label>
+      <div>
+      <a style="color: lightblue;" href="https://github.com/google/cameratrapai">SpeciesNet</a>
+        <label>&copy 2024 Google LLC is used under an Apache 2.0 License</label>
+      </div></footer>
   </div>
 
   <!-- Auth initialising -->

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -107,6 +107,23 @@
             {{ formatElapsed(elapsedSec) }}
           </span>
         </div>
+
+        <!-- Streaming thumbnail of the most-recently-classified animal
+             (≥50% confidence). Appears as soon as inference has produced
+             at least one qualifying prediction; updates in place every
+             time a new one lands. -->
+        <div v-if="showLatestCrop" class="latest-crop">
+          <img
+            :src="latestCropUrl"
+            :alt="job.latest_animal_crop.common_name"
+            class="latest-crop__img"
+          />
+          <div class="latest-crop__meta">
+            <span class="latest-crop__heading">Latest classification</span>
+            <span class="latest-crop__name">{{ capitalize(job.latest_animal_crop.common_name) }}</span>
+            <span class="latest-crop__score">{{ Math.round(job.latest_animal_crop.score * 100) }}% confidence</span>
+          </div>
+        </div>
       </div>
 
       <!-- ── Inference progress ── -->
@@ -126,6 +143,23 @@
           Loading the AI model. This typically takes 30–60 seconds on the
           first upload and is much faster on subsequent runs.
         </p>
+
+        <!-- Streaming thumbnail of the most-recently-classified animal
+             (≥50% confidence). Same panel as in the upload phase; lives
+             here too so it stays visible as predictions stream in
+             throughout inference. -->
+        <div v-if="showLatestCrop" class="latest-crop">
+          <img
+            :src="latestCropUrl"
+            :alt="job.latest_animal_crop.common_name"
+            class="latest-crop__img"
+          />
+          <div class="latest-crop__meta">
+            <span class="latest-crop__heading">Latest classification</span>
+            <span class="latest-crop__name">{{ capitalize(job.latest_animal_crop.common_name) }}</span>
+            <span class="latest-crop__score">{{ Math.round(job.latest_animal_crop.score * 100) }}% confidence</span>
+          </div>
+        </div>
 
         <div v-if="progressEntries.length" class="progress__stages">
           <div v-for="[label, p] in progressEntries" :key="label" class="progress__stage">
@@ -224,7 +258,7 @@
 
 <script setup>
 import { ref, computed, watch, nextTick, onUnmounted } from 'vue'
-import { AUTH_ENABLED, apiFetch } from '../firebase.js'
+import { AUTH_ENABLED, apiFetch, imageUrl } from '../firebase.js'
 
 const emit = defineEmits(['close', 'done'])
 
@@ -301,6 +335,23 @@ const showWaitingHint = computed(() =>
   phase.value === 'processing'
   && (job.value.status === 'pending' || job.value.status === 'running')
   && progressEntries.value.length === 0,
+)
+
+// Streaming thumbnail: the inference job writes `latest_animal_crop` on
+// every prediction that's an animal with ≥50% confidence (see job.py).
+// Show it whenever there's something to show AND the job hasn't reached
+// its final state — once status === 'done' the full summary panel takes
+// over. Hidden if status === 'error' to avoid stale state alongside the
+// error banner.
+const showLatestCrop = computed(() =>
+  job.value.latest_animal_crop
+  && job.value.status !== 'done'
+  && job.value.status !== 'error',
+)
+const latestCropUrl = computed(() =>
+  job.value.latest_animal_crop
+    ? imageUrl(job.value.latest_animal_crop.crop_gcs_path)
+    : '',
 )
 
 function formatElapsed(s) {
@@ -931,5 +982,55 @@ onUnmounted(() => {
 .progress__details-toggle:hover {
   color: var(--text);
   text-decoration: underline;
+}
+
+/* Streaming "latest classification" thumbnail panel */
+.latest-crop {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.latest-crop__img {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  background: var(--surface);
+  flex-shrink: 0;
+}
+
+.latest-crop__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.latest-crop__heading {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.latest-crop__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--animal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.latest-crop__score {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }
 </style>


### PR DESCRIPTION
## Summary
Builds on [#34](https://github.com/dabearic/trackcam-viewer/pull/34)'s streaming-predictions plumbing. The inference job already writes Firestore docs as classifications complete; this PR surfaces the most-recently-classified animal as a live thumbnail in the upload dialog so the user sees what the AI is finding instead of staring at a progress bar.

> **Base branch is \`claude/stream-predictions-as-they-arrive\` (#34), not main.** Will rebase to main automatically once #34 lands.

## Backend (job.py)
After each prediction is written to Firestore, the worker checks: is it \`category=animal\`, \`prediction_score >= 0.5\`, and does it have at least one detection with a \`crop_gcs_path\`? If yes, it writes a \`latest_animal_crop\` field on the job doc:

\`\`\`json
{
  "filename": "IMG_0042.jpg",
  "common_name": "white-tailed deer",
  "score": 0.91,
  "crop_gcs_path": "crops/<uid>/<folder>/IMG_0042_detection_1.jpg",
  "classified_at": "2026-04-30T20:08:13.456789+00:00"
}
\`\`\`

Concurrent writes from multiple workers are last-writer-wins, which matches the desired "show the most recent" semantics — whichever prediction completed most recently wins the slot.

The filter (animal & ≥50% & has crop) lives entirely in this write path. We never write \`latest_animal_crop\` for non-qualifying predictions, so the UI doesn't need its own score check — just \`v-if="job.latest_animal_crop"\`.

## Frontend (ProcessModal.vue)
New \`.latest-crop\` panel appears whenever \`job.latest_animal_crop\` is set and the job isn't in a terminal state. Renders in both the 'uploading' and 'processing' phases so it stays visible across the dialog's lifecycle. The image goes through the existing \`/api/image\` proxy via \`imageUrl()\`, same path as gallery thumbnails.

Visual: 64×64 thumbnail on the left, three lines of metadata on the right (label / common name in animal-green / score percentage). Updates in place each polling cycle (2 s) — when a new qualifying prediction arrives, the panel swaps to that one without unmounting.

| State | Panel visibility |
|---|---|
| No predictions yet | Hidden |
| First qualifying prediction lands | Appears |
| Newer one lands | Updates in place |
| All non-qualifying predictions arrive | Stays on the most recent qualifying one |
| Job done | Hidden (full summary takes over) |
| Job error | Hidden (error banner takes over) |

## Concurrency notes (Firestore writes)
Worst-case sustained rate to the single job doc: ~2 writes/sec from \`set_status\` calls + ~3 writes/sec from \`latest_animal_crop\` updates on a typical batch. Within Firestore's burst tolerance. If the per-doc rate-limit ever becomes an issue at very high detection densities, the mitigation is a worker-side throttle ("only update if last write was >Ns ago") — but that's premature for the rates we're seeing in production runs.

## What this does NOT change
- Crop generation thresholds (CROP_CONF_THRESHOLD = 0.2, unchanged)
- Per-prediction Firestore docs — unchanged shape
- Final summary panel — unchanged
- The /api/image endpoint — already supports \`crops/\` paths

## Test plan
- [x] Build the inference image (depends on #34's changes), deploy
- [x] Build the frontend with this branch
- [x] Run a detection-heavy batch — verify the thumbnail panel appears within ~10 s of the first qualifying prediction landing
- [x] Verify the thumbnail updates as new qualifying predictions stream in
- [x] Verify the panel disappears when status flips to 'done'
- [x] Run an all-blank/all-human batch (rare) — verify the panel never appears
- [x] Check for Firestore quota warnings in Cloud Logging during a long run

🤖 Generated with [Claude Code](https://claude.com/claude-code)