### PR TITLE
Add cleanup script for failure-stub recovery

### DIFF
--- a/infra/scripts/cleanup_failure_stubs.py
+++ b/infra/scripts/cleanup_failure_stubs.py
@@ -1,0 +1,93 @@
+"""
+One-shot recovery for the failure-stub bug introduced (and fixed) in PR #34.
+
+PR #34 added streaming-prediction processing — a watcher thread that reads
+the predictions.json speciesnet writes periodically and dispatches new
+entries to per-prediction workers. Speciesnet's _merge_results function
+writes a `{filepath, failures: [name]}` placeholder for every input
+filepath whose pipeline stage hasn't completed yet, so a periodic save
+fired before all images had been classified contained 10 real entries +
+N failure stubs. The original streaming code processed those stubs as if
+they were finished predictions, claiming the filepath in
+`processed_filepaths` and ignoring the real prediction when it arrived
+later. Result: many animals incorrectly written as blank-with-failures
+to Firestore.
+
+The streaming code has since been fixed to skip failure stubs in-progress
+and only accept them in the final scan after speciesnet exits. This
+script cleans up any docs that landed in Firestore from the buggy window.
+
+Identification: a stub doc has `prediction is None` AND `failures` is
+non-empty AND comes from the affected `job_id`. Real predictions —
+even ones with partial component failures (e.g. GEOLOCATION failed but
+classifier worked) — keep `prediction` set, so they're untouched.
+
+Environment:
+  GCP_PROJECT.
+  Google ADC with Firestore read/write.
+
+Usage:
+  python infra/scripts/cleanup_failure_stubs.py --uid UID --job-id JOBID [--dry-run]
+
+The job_id is the firestore job-doc ID (8-char hex) — NOT the Cloud Run
+execution suffix. Find it on any of the bad prediction docs in the
+Firestore console (the `job_id` field), or on the job's own doc under
+users/<uid>/jobs/<job_id>.
+"""
+import argparse
+import os
+
+from google.cloud import firestore
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--uid",     required=True, help="Firebase UID whose predictions to clean")
+    ap.add_argument("--job-id",  required=True, help="Firestore job_id (NOT the Cloud Run execution suffix)")
+    ap.add_argument("--dry-run", action="store_true", help="List doomed docs without deleting")
+    args = ap.parse_args()
+
+    project = os.environ["GCP_PROJECT"]
+    db = firestore.Client(project=project)
+    pred_col = (
+        db.collection("users").document(args.uid)
+        .collection("predictions")
+    )
+
+    # Materialise the query before doing per-doc work so the gRPC stream
+    # can close cleanly (mirrors backfill_taken_at.py:99).
+    docs = list(pred_col.where("job_id", "==", args.job_id).stream())
+    print(f"Scanned {len(docs)} prediction(s) for job {args.job_id}")
+
+    doomed = []
+    for snap in docs:
+        d = snap.to_dict()
+        # Conservative filter: only docs that have NO ensembled prediction
+        # AND non-empty failures. Predictions where some pipeline stage
+        # failed but ensemble still produced a label keep `prediction`
+        # set, so they're left alone.
+        if d.get("prediction") is None and d.get("failures"):
+            doomed.append((snap.reference, d.get("filename"), d.get("failures")))
+
+    if not doomed:
+        print("No failure-stub docs found. Nothing to delete.")
+        return
+
+    print(f"Found {len(doomed)} failure-stub doc(s):")
+    preview = doomed[:20]
+    for _, name, failures in preview:
+        print(f"  {name}  failures={failures}")
+    if len(doomed) > len(preview):
+        print(f"  ... and {len(doomed) - len(preview)} more")
+
+    if args.dry_run:
+        print(f"\n(dry-run — no deletes performed)")
+        return
+
+    for ref, name, _ in doomed:
+        ref.delete()
+    print(f"\nDeleted {len(doomed)} doc(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/cleanup_failure_stubs.py
+++ b/infra/scripts/cleanup_failure_stubs.py
@@ -26,8 +26,23 @@ Environment:
   GCP_PROJECT.
   Google ADC with Firestore read/write.
 
-Usage:
-  python infra/scripts/cleanup_failure_stubs.py --uid UID --job-id JOBID [--dry-run]
+Dependencies:
+  pip install google-cloud-firestore
+
+Usage (bash / Linux / macOS):
+  GCP_PROJECT=trackcam-viewer python infra/scripts/cleanup_failure_stubs.py \
+      --uid UID --job-id JOBID --dry-run
+
+Usage (PowerShell on Windows):
+  $env:GCP_PROJECT="trackcam-viewer"
+  py infra/scripts/cleanup_failure_stubs.py --uid UID --job-id JOBID --dry-run
+
+  On Windows the bare `python` command is intercepted by the Microsoft
+  Store app-execution alias; use `py` (the Python launcher) instead.
+  If `from google.cloud import firestore` fails, run
+  `py -m pip install google-cloud-firestore` — the user-site install
+  path is not always on Python's import search list depending on how
+  your shell is configured.
 
 The job_id is the firestore job-doc ID (8-char hex) — NOT the Cloud Run
 execution suffix. Find it on any of the bad prediction docs in the


### PR DESCRIPTION
## Summary
Recovery utility for the bug fixed in PR [#34](https://github.com/dabearic/trackcam-viewer/pull/34) (commit \`88a2ea2\`). The first iteration of the streaming code wrote prediction docs whose \`prediction\` field was \`None\` and \`failures\` was \`[\"DETECTOR.name\"]\` (or similar) for every image speciesnet hadn't yet finished processing. Even after deploying the fix, those bad docs are stuck in Firestore — \`/api/upload/prepare\`'s dedup logic skips any gcs_path that already has a prediction doc, so the obvious "just re-upload" workaround does not work.

This script identifies bad docs by their telltale shape and deletes them, scoped to a single \`job_id\` for safety.

## How it identifies a stub
- \`prediction is None\` AND \`failures\` is non-empty
- Real predictions — even ones with partial component failures (e.g. classifier worked but GEOLOCATION lookup failed) — keep \`prediction\` set, so they're left alone

## Usage
\`\`\`
GCP_PROJECT=trackcam-viewer python infra/scripts/cleanup_failure_stubs.py \
  --uid <FIREBASE_UID> \
  --job-id <FIRESTORE_JOB_ID> \
  --dry-run
\`\`\`

\`--dry-run\` first to preview the list (prints filename + failures for the first 20). Drop \`--dry-run\` once you're satisfied.

The \`job_id\` is the 8-char hex ID on the Firestore job doc — **not** the Cloud Run execution suffix (\`g7jrp\`-style). Pull it from the \`job_id\` field on any of the bad prediction docs in the Firestore console, or from the URL in the upload dialog.

## After running
Re-upload the affected images normally — the dedup check now sees no existing docs, the inference runs cleanly with the fixed streaming code, and the predictions land correctly.

## Test plan
- [x] Run with \`--dry-run\` first against the bad job from execution \`g7jrp\` — verify it finds approximately the expected count of failure-stub docs and lists their filenames
- [x] Run without \`--dry-run\`, verify the docs are gone from the Firestore console
- [x] Re-upload the same images — verify they're no longer skipped by dedup, the new run produces correct predictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)