### PR TITLE
Restore streaming-thumbnail content from #35 (lost via merge ordering)

### DIFF
--- a/infra/inference/job.py
+++ b/infra/inference/job.py
@@ -363,6 +363,32 @@ def main():
                     "category":    category,
                 })
 
+            # Surface a "latest qualifying crop" pointer on the job doc so
+            # the upload-dialog UI can render a live thumbnail of the most-
+            # recently-classified animal without subscribing to Firestore
+            # or running a separate query (the doc is already polled every
+            # 2s for status). Concurrent updates from multiple workers are
+            # last-writer-wins, which is exactly the desired semantics:
+            # whichever prediction completed most recently wins the slot.
+            score = pred.get("prediction_score") or 0
+            if category == "animal" and score >= 0.5:
+                best_crop = max(
+                    (d for d in pred.get("detections", []) if d.get("crop_gcs_path")),
+                    key=lambda d: d.get("conf", 0),
+                    default=None,
+                )
+                if best_crop:
+                    job_ref.update({
+                        "latest_animal_crop": {
+                            "filename":      filename,
+                            "common_name":   common,
+                            "score":         round(score, 3),
+                            "crop_gcs_path": best_crop["crop_gcs_path"],
+                            "classified_at": now_iso,
+                        },
+                        "updated_at": now_iso,
+                    })
+
             with count_lock:
                 count += 1
                 my_count = count

--- a/webapp/frontend/src/App.vue
+++ b/webapp/frontend/src/App.vue
@@ -135,6 +135,11 @@
         </div>
       </div>
     </div>
+    <footer style="width: 100%"><label>TrailCam Viewer Copyright &copy 2026</label>
+      <div>
+      <a style="color: lightblue;" href="https://github.com/google/cameratrapai">SpeciesNet</a>
+        <label>&copy 2024 Google LLC is used under an Apache 2.0 License</label>
+      </div></footer>
   </div>
 
   <!-- Auth initialising -->

--- a/webapp/frontend/src/components/ProcessModal.vue
+++ b/webapp/frontend/src/components/ProcessModal.vue
@@ -107,6 +107,23 @@
             {{ formatElapsed(elapsedSec) }}
           </span>
         </div>
+
+        <!-- Streaming thumbnail of the most-recently-classified animal
+             (≥50% confidence). Appears as soon as inference has produced
+             at least one qualifying prediction; updates in place every
+             time a new one lands. -->
+        <div v-if="showLatestCrop" class="latest-crop">
+          <img
+            :src="latestCropUrl"
+            :alt="job.latest_animal_crop.common_name"
+            class="latest-crop__img"
+          />
+          <div class="latest-crop__meta">
+            <span class="latest-crop__heading">Latest classification</span>
+            <span class="latest-crop__name">{{ capitalize(job.latest_animal_crop.common_name) }}</span>
+            <span class="latest-crop__score">{{ Math.round(job.latest_animal_crop.score * 100) }}% confidence</span>
+          </div>
+        </div>
       </div>
 
       <!-- ── Inference progress ── -->
@@ -126,6 +143,23 @@
           Loading the AI model. This typically takes 30–60 seconds on the
           first upload and is much faster on subsequent runs.
         </p>
+
+        <!-- Streaming thumbnail of the most-recently-classified animal
+             (≥50% confidence). Same panel as in the upload phase; lives
+             here too so it stays visible as predictions stream in
+             throughout inference. -->
+        <div v-if="showLatestCrop" class="latest-crop">
+          <img
+            :src="latestCropUrl"
+            :alt="job.latest_animal_crop.common_name"
+            class="latest-crop__img"
+          />
+          <div class="latest-crop__meta">
+            <span class="latest-crop__heading">Latest classification</span>
+            <span class="latest-crop__name">{{ capitalize(job.latest_animal_crop.common_name) }}</span>
+            <span class="latest-crop__score">{{ Math.round(job.latest_animal_crop.score * 100) }}% confidence</span>
+          </div>
+        </div>
 
         <div v-if="progressEntries.length" class="progress__stages">
           <div v-for="[label, p] in progressEntries" :key="label" class="progress__stage">
@@ -224,7 +258,7 @@
 
 <script setup>
 import { ref, computed, watch, nextTick, onUnmounted } from 'vue'
-import { AUTH_ENABLED, apiFetch } from '../firebase.js'
+import { AUTH_ENABLED, apiFetch, imageUrl } from '../firebase.js'
 
 const emit = defineEmits(['close', 'done'])
 
@@ -301,6 +335,23 @@ const showWaitingHint = computed(() =>
   phase.value === 'processing'
   && (job.value.status === 'pending' || job.value.status === 'running')
   && progressEntries.value.length === 0,
+)
+
+// Streaming thumbnail: the inference job writes `latest_animal_crop` on
+// every prediction that's an animal with ≥50% confidence (see job.py).
+// Show it whenever there's something to show AND the job hasn't reached
+// its final state — once status === 'done' the full summary panel takes
+// over. Hidden if status === 'error' to avoid stale state alongside the
+// error banner.
+const showLatestCrop = computed(() =>
+  job.value.latest_animal_crop
+  && job.value.status !== 'done'
+  && job.value.status !== 'error',
+)
+const latestCropUrl = computed(() =>
+  job.value.latest_animal_crop
+    ? imageUrl(job.value.latest_animal_crop.crop_gcs_path)
+    : '',
 )
 
 function formatElapsed(s) {
@@ -931,5 +982,55 @@ onUnmounted(() => {
 .progress__details-toggle:hover {
   color: var(--text);
   text-decoration: underline;
+}
+
+/* Streaming "latest classification" thumbnail panel */
+.latest-crop {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.latest-crop__img {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  background: var(--surface);
+  flex-shrink: 0;
+}
+
+.latest-crop__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.latest-crop__heading {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.latest-crop__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--animal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.latest-crop__score {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }
 </style>


### PR DESCRIPTION
## Summary
PR [#35](https://github.com/dabearic/trackcam-viewer/pull/35) ("Stream a 'latest classification' thumbnail in the upload dialog") shows MERGED on GitHub but its content is **not on main**. The PR's base branch was \`claude/stream-predictions-as-they-arrive\` (#34's source branch), and #34 had already merged into main *before* #35 merged into that branch — so #35's commits ended up in a now-deleted feature branch and never propagated to main.

\`\`\`
$ git grep latest_animal_crop origin/main
(no output)
\`\`\`

This PR restores #35's content by cherry-picking its squash commit (\`de8e14d4\`) onto a branch from current main. No conflicts on the cherry-pick — main's #34 content already has the failure-stub fix that was added during #34's review, so the restoration applies cleanly on top.

## What this restores
- **\`infra/inference/job.py\`** — the per-prediction \`latest_animal_crop\` write that drives the streaming thumbnail and the accumulating crop gallery in [PR #37 / claude/process-dialog-rework](https://github.com/dabearic/trackcam-viewer/pull/new/claude/process-dialog-rework).
- **\`webapp/frontend/src/components/ProcessModal.vue\`** — the original streaming-thumbnail panel that appears during the run.
- **\`webapp/frontend/src/App.vue\`** — copyright footer (was bundled into #35's squash, restored as-is).

## Why merge this first
The dialog-rework PR adds a post-completion crop gallery that reads \`job.latest_animal_crop\` from each polling response and accumulates them client-side. Without this restoration, that gallery has nothing to read — the field is never written.

After this lands, I'll rebase the dialog-rework branch onto the new main and push.

## Test plan
- [x] Build + deploy
- [x] Run a batch with at least a few animal classifications above 50% confidence
- [x] Verify the streaming-thumbnail panel appears during the run
- [x] Verify \`latest_animal_crop\` is set on the job doc in Firestore as predictions complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)