### PR TITLE
Parallelize signed-URL generation in /api/upload/prepare

### DIFF
--- a/webapp/backend/main_cloud.py
+++ b/webapp/backend/main_cloud.py
@@ -13,6 +13,7 @@ import os
 import urllib.parse
 import urllib.request
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
@@ -221,20 +222,34 @@ async def prepare_upload(
         raise HTTPException(status_code=400, detail="No filenames provided")
 
     folder = _safe_folder(req.folder)
-    uploads = []
-    for raw_name in req.filenames:
-        filename = Path(raw_name).name  # strip any path component
-        if Path(filename).suffix.lower() not in IMAGE_EXTS:
-            continue
+    filenames = [
+        Path(raw_name).name  # strip any path component
+        for raw_name in req.filenames
+        if Path(raw_name).suffix.lower() in IMAGE_EXTS
+    ]
+
+    # Sign URLs in parallel. generate_signed_url with explicit
+    # service_account_email + access_token uses the IAM signBlob API
+    # (~150ms per call) because Cloud Run's compute-engine creds can't
+    # sign locally. Serialized, a 100-file batch spent ~15s here before
+    # uploads could even start. Pull the access token once, then fan
+    # out so total prep time is bounded by one round-trip plus the
+    # number of batches the pool serializes through.
+    sign_kwargs = _sign_kwargs()
+
+    def _sign_one(filename: str) -> dict:
         gcs_path = f"images/{uid}/{folder}/{filename}"
         url = _bucket.blob(gcs_path).generate_signed_url(
             expiration=timedelta(minutes=30),
             method="PUT",
             content_type="image/jpeg",
             version="v4",
-            **_sign_kwargs(),
+            **sign_kwargs,
         )
-        uploads.append({"filename": filename, "gcs_path": gcs_path, "url": url})
+        return {"filename": filename, "gcs_path": gcs_path, "url": url}
+
+    with ThreadPoolExecutor(max_workers=32) as ex:
+        uploads = list(ex.map(_sign_one, filenames))
 
     if not uploads:
         return {


### PR DESCRIPTION
## Summary
Cloud Run's compute-engine credentials can't sign URLs locally, so every \`generate_signed_url(version="v4", service_account_email=…, access_token=…)\` call hits the **IAM signBlob API** — ~150 ms per call. The prep endpoint signed them serially, so a 107-file batch spent **17.2 s** in the prep call before uploads could start (measured in HAR).

The signing calls are independent — each blob's path is distinct and the same IAM access token works for all of them. Pull \`_sign_kwargs()\` once, share the access_token across threads, fan out via a 32-worker \`ThreadPoolExecutor\`.

## Expected impact

| | Before | After |
|---|---:|---:|
| 1 file | ~150 ms | ~150 ms |
| 100 files | ~15 s | ~600 ms (4 batches × 150 ms) |
| 107 files (measured) | 17.2 s | should land near ~600 ms |
| 500 files | ~75 s | ~2.4 s (16 batches) |

Total upload-prepare cost drops from "noticeable stall" to "barely perceptible."

## Why not a bigger refactor

Could also:
- Switch to a downloadable service-account key for **local** signing (no IAM round-trip at all → instant). Security tradeoff (key management) and a bigger change.
- Dedup *before* signing to skip throwaway signs for already-uploaded files. With parallelization, the wall time is dominated by one round-trip regardless of batch size, so the savings would be small. Not worth the refactor.

This PR is the small targeted fix; the bigger refactors are available later if needed.

## What this does NOT change
- Response shape — byte-identical to before
- Dedup logic
- Job-doc creation
- The \`run_job.create\` call
- Anything outside the signing loop

## Test plan
- [ ] Deploy via \`./infra/deploy-api.ps1\`
- [ ] Network tab → POST \`/api/upload/prepare\` for a 50–100-file batch should land in <1 s
- [ ] Compare against the 17.2 s baseline from the HAR
- [ ] Verify uploads start as soon as the response arrives (no regression in browser behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)